### PR TITLE
Revise extras

### DIFF
--- a/src/calculate/displacements.py
+++ b/src/calculate/displacements.py
@@ -1,21 +1,35 @@
 import numpy as np
 
 
-class Displacements():
+class Displacements:
 
     @staticmethod
-    def calculate_all(data,
-                      equilibration_steps: int,
-                      diffusing_element: str = 'Li',
-                      **kwargs) -> dict:
+    def calculate_all(data, extras) -> dict:
+        """Calculate displacement properties.
+
+        Parameters
+        ----------
+        data : SimulationData
+            Input simulation data
+        extras : SimpleNamespace
+            Extra variables
+
+        Returns
+        -------
+        extras : dict[str, float]
+            Dictionary with calculated parameters
+        """
         cell_offsets = Displacements.cell_offsets(data.trajectory_coords),
+
         displacements = Displacements.displacements(data.trajectory_coords,
                                                     data.lattice,
-                                                    equilibration_steps)
+                                                    extras.equilibration_steps)
+
         diff_displacements = Displacements.diff_displacements(
             displacements=displacements,
-            diffusing_element=diffusing_element,
+            diffusing_element=extras.diffusing_element,
             species=data.species)
+
         return {
             'cell_offsets': cell_offsets,
             'displacements': displacements,

--- a/src/calculate/tracer.py
+++ b/src/calculate/tracer.py
@@ -5,73 +5,47 @@ from gemdat.constants import avogadro, e_charge, k_boltzmann
 class Tracer:
 
     @staticmethod
-    def calculate_all(
-        data,
-        displacements: np.ndarray,
-        equilibration_steps: int,
-        diffusing_element: str,
-        dimensions: int = 3,
-        z_ion: int = 1,
-        **kwargs,
-    ) -> dict[str, float]:
+    def calculate_all(data, extras) -> dict[str, float]:
         """Calculate tracer properties.
 
         Parameters
         ----------
         data : SimulationData
             Input simulation data
-        equilibration_steps : int
-            Number of equilbiration steps
-        diffusing_element : str
-            Name of the diffusing element
-        displacements : np.ndarray
-            Input array with displacements
-        dimensions : int
-            Number of diffusion dimensions
-        z_ion : int
-            Ionic charge of the diffusing ion
+        extras : SimpleNamespace
+            Extra variables
 
         Returns
         -------
         extras : dict[str, float]
-            Dictionary with calculate parameters
+            Dictionary with calculated parameters
         """
-        time_step = data.time_step
-        n_diffusing = sum([e.name == diffusing_element for e in data.species])
-
         angstrom_to_meter = 1e-10
 
-        n_steps = len(data.trajectory_coords) - equilibration_steps
-        len(data.species)
-
-        total_time = n_steps * time_step
+        total_time = extras.n_steps * data.time_step
 
         volume_ang = data.lattice.volume
         volume_m3 = volume_ang * angstrom_to_meter**3
 
-        particle_density = n_diffusing / volume_m3
+        particle_density = extras.n_diffusing / volume_m3
 
         mol_per_liter = (particle_density * 1e-3) / avogadro
 
         print(f'{particle_density=:g} m^-3')
         print(f'{mol_per_liter=:g} mol/l')
 
-        # grab displacements for diffusing element only
-        idx = np.argwhere([e.name == diffusing_element for e in data.species])
-        diff_displacements = displacements[idx].squeeze()
-
         # Matlab code contains a bug here so I'm not entirely sure what is the definition
         # Matlab code takes the first column, which is equal to 0
         # Do they mean the total displacement (i.e. last column)?
-        msd = np.mean(diff_displacements[:, -1]**2)  # Angstron^2
+        msd = np.mean(extras.diff_displacements[:, -1]**2)  # Angstron^2
 
         temperature = data.temperature
 
         # Diffusivity = MSD/(2*dimensions*time)
-        tracer_diff = (msd * angstrom_to_meter**2) / (2 * dimensions *
-                                                      total_time)
+        tracer_diff = (msd * angstrom_to_meter**2) / (
+            2 * extras.diffusion_dimensions * total_time)
         # Conductivity = elementary_charge^2 * charge_ion^2 * diffusivity * particle_density / (k_B * T)
-        tracer_conduc = ((e_charge**2) * (z_ion**2) * tracer_diff *
+        tracer_conduc = ((e_charge**2) * (extras.z_ion**2) * tracer_diff *
                          particle_density) / (k_boltzmann * temperature)
 
         print(f'{tracer_diff=:g} m^2/s')

--- a/src/calculate/vibration.py
+++ b/src/calculate/vibration.py
@@ -2,13 +2,28 @@ import numpy as np
 from scipy import signal
 
 
-class Vibration():
+class Vibration:
 
     @staticmethod
-    def calculate_all(data, diffusing_element: str, equilibration_steps: int,
-                      diff_displacements: np.ndarray, **kwargs) -> dict:
+    def calculate_all(data, extras) -> dict:
+        """Calculate Vibration properties.
+
+        Parameters
+        ----------
+        data : SimulationData
+            Input simulation data
+        extras : SimpleNamespace
+            Extra variables
+
+        Returns
+        -------
+        extras : dict[str, float]
+            Dictionary with calculated parameters
+        """
+        fs = 1 / data.time_step
+
         speed, attempt_freq, attempt_freq_std = Vibration.attempt_frequency(
-            diff_displacements, data.time_step)
+            extras.diff_displacements, fs=fs)
         amplitudes, vibration_amplitude = Vibration.amplitude(speed)
 
         return {
@@ -17,7 +32,7 @@ class Vibration():
             'attempt_freq_std': attempt_freq_std,
             'amplitudes': amplitudes,
             'vibration_amplitude': vibration_amplitude,
-            'fs': 1 / data.time_step,
+            'fs': fs,
         }
 
     @staticmethod
@@ -56,7 +71,7 @@ class Vibration():
         return mnfreq
 
     @staticmethod
-    def attempt_frequency(displacements: np.ndarray, time_step: float = 1):
+    def attempt_frequency(displacements: np.ndarray, fs: float = 1):
         """Calculate attempt frequency.
 
         Parameters
@@ -75,8 +90,6 @@ class Vibration():
         attempt_freq_std : float
             Attempt frequency standard deviation
         """
-
-        fs = 1 / time_step
         speed = np.diff(displacements, prepend=0)
 
         freq_mean = Vibration.meanfreq(speed, fs=fs)

--- a/src/dashboard/run.py
+++ b/src/dashboard/run.py
@@ -62,7 +62,7 @@ extra = data.calculate_all(equilibration_steps=equilibration_steps,
 with fig_tab:
     st.title('GEMDAT pregenerated figures')
 
-    figures = plot_all(data=data, **extra, show=False)
+    figures = plot_all(data=data, **vars(extra), show=False)
 
     # automagically divide the plots over the number of columns
     for num, col in enumerate(st.columns(number_of_cols)):

--- a/src/data.py
+++ b/src/data.py
@@ -107,12 +107,10 @@ class SimulationData:
 
         self._add_shared_variables(extras)
 
-        for obj in (
-                Displacements,
-                Vibration,
-                Tracer,
-        ):
-            extras.__dict__.update(obj.calculate_all(self, extras=extras))
+        extras.__dict__.update(Displacements.calculate_all(self,
+                                                           extras=extras))
+        extras.__dict__.update(Vibration.calculate_all(self, extras=extras))
+        extras.__dict__.update(Tracer.calculate_all(self, extras=extras))
 
         return extras
 

--- a/src/data.py
+++ b/src/data.py
@@ -76,7 +76,7 @@ class SimulationData:
                       z_ion: float = 1.0,
                       n_parts: int = 10,
                       dist_collective: float = 4.5):
-        """Calculate extra parameters and place them in `.extras` attribute and return self.extras.
+        """Calculate extra parameters and return them as a simple namespace.
 
         Parameters
         ----------


### PR DESCRIPTION
This PR revises the way extras are handled and passes them around as a `SimpleNamespace`. This makes it a bit easier to pass them around and get the attribrutes. We can convert this to a class/dataclass at a later stage if necessary.

The `calculate_all` now expect `data` + `extras` but they still return dicts with the data which are then added to `extras`.

