### PR TITLE
Calculate origin and destination sites for atoms in transition

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,43 @@
+import numpy as np
+
+
+def ffill(arr: np.ndarray, fill_val: int = -1, axis=-1) -> np.ndarray:
+    """Forward fill values equal to `val` with most recent values.
+
+    Parameters
+    ----------
+    arr : np.ndarray
+        Input array with 2 dimensions
+    fill_val : int, optional
+        Value to fill
+    axis : int, optional
+        Axis along which to operate
+
+    Returns
+    -------
+    out : np.ndarray
+        Output array with all values
+    """
+    if axis == 0:
+        return ffill(arr.T).T
+
+    if arr.ndim > 2:
+        raise ValueError
+
+    idx = np.where(arr != fill_val, np.arange(arr.shape[1]), 0)
+    np.maximum.accumulate(idx, axis=1, out=idx)
+    return arr[np.arange(idx.shape[0])[:, None], idx]
+
+
+def bfill(arr: np.ndarray, fill_val: int = -1, axis=-1) -> np.ndarray:
+    """Backward fill.
+
+    See ffill for options.
+    """
+    if axis == 0:
+        return bfill(arr.T).T
+
+    if arr.ndim > 2:
+        raise ValueError
+
+    return np.fliplr(ffill(np.fliplr(arr), fill_val=fill_val))

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -64,6 +64,10 @@ def test_sites(gemdat_results):
 
     assert sites.atom_sites.shape == (73750, 48)
     assert sites.atom_sites.sum() == 9228360
+    assert sites.atom_sites_to.shape == (73750, 48)
+    assert sites.atom_sites_to.sum() == 84831031
+    assert sites.atom_sites_from.shape == (73750, 48)
+    assert sites.atom_sites_from.sum() == 85351052
 
     assert sites.all_transitions.shape == (1336, 5)
 

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,0 +1,56 @@
+import numpy as np
+import pytest
+from gemdat.utils import bfill, ffill
+
+
+@pytest.fixture
+def arr():
+    return np.array([
+        [5, -1, -1, 7, 2],
+        [3, -1, 1, 8, -1],
+        [4, 9, 6, -1, -1],
+    ])
+
+
+def test_ffill(arr):
+    ret = ffill(arr)
+    expected = np.array([
+        [5, 5, 5, 7, 2],
+        [3, 3, 1, 8, 8],
+        [4, 9, 6, 6, 6],
+    ])
+
+    np.testing.assert_equal(ret, expected)
+
+
+def test_bfill(arr):
+    ret = bfill(arr)
+    expected = np.array([
+        [5, 7, 7, 7, 2],
+        [3, 1, 1, 8, -1],
+        [4, 9, 6, -1, -1],
+    ])
+
+    np.testing.assert_equal(ret, expected)
+
+
+def test_ffill_axis0(arr):
+    ret = ffill(arr, axis=0)
+    expected = np.array([
+        [5, -1, -1, 7, 2],
+        [3, -1, 1, 8, 2],
+        [4, 9, 6, 8, 2],
+    ])
+
+    np.testing.assert_equal(ret, expected)
+
+
+def test_bfill_axis0(arr):
+    ret = bfill(arr, axis=0)
+    expected = np.array([
+        [5, 9, 1, 7, 2],
+        [3, 9, 1, 8, -1],
+        [4, 9, 6, -1, -1],
+    ])
+
+    np.testing.assert_equal(ret, expected)


### PR DESCRIPTION
In the matlab code, the location of each atom is tracked through `sites.atom_sites`. The index corresponds to a number that is generated on the fly. The states are in a different array called `sites.site_names`.

This array contains these values:

- `48h` : Atom is currently sitting at this site
- `Transition:48h` : Atom is currently in transition, but will go back to itself (48h)
- `Transition:48h-48h` : Atom is currently in transition from 48h to another site named 48h

The index in `atom_sites` corresponds to en element in `sites.site_names` containing these values.

I have taken a different approach. For each time step, I calculate the index of the current, previous and next site. `atom_sites` tracks the index of the site the atom is currently at. `-1` indicates the atom is in transition. `atom_sites_from` and `atom_sites_to` track the origin and destination of an atom (`-1` when not available). If an atom is at a site, the corresponding elements of all three arrays are equal. This is both easier to calculate and I believe this data will be easier to work for further analysis.