### PR TITLE
Add legacy interface to mimick matlab code

### DIFF
--- a/src/legacy.py
+++ b/src/legacy.py
@@ -3,10 +3,12 @@ from types import SimpleNamespace
 from gemdat import SimulationData, SitesData, load_known_material, plot_all
 from gemdat.plots.jumps import plot_jumps_3d_animation
 from gemdat.rdf import calculate_rdfs, plot_rdf
+from gemdat.volume import trajectory_to_vasp_volume
 
 
 def analyse_md(
     vasp_xml: str,
+    *,
     diff_elem: str,
     material: str,
     supercell: tuple[int, int, int] | None = None,
@@ -108,9 +110,11 @@ def analyse_md(
     for name, rdf in rdfs.items():
         plot_rdf(rdf, name=name)
 
-    # trajectory_to_vasp_volume(coords=data.trajectory_coords,
-    # structure=data.structure,
-    # resolution=density_resolution,
-    # filename='volume.vasp')
+    filename = 'volume.vasp'
+    print(f'Writing trajectory as a volume to `{filename}')
+    trajectory_to_vasp_volume(coords=data.trajectory_coords,
+                              structure=data.structure,
+                              resolution=density_resolution,
+                              filename=filename)
 
     return data, sites, extras

--- a/src/legacy.py
+++ b/src/legacy.py
@@ -69,8 +69,10 @@ def analyse_md(
     """
     data = SimulationData.from_vasprun(vasp_xml)
 
+    equilibration_steps = round(equil_time / data.time_step)
+
     extras = data.calculate_all(
-        equilibration_steps=1250,
+        equilibration_steps=equilibration_steps,
         diffusing_element=diff_elem,
         z_ion=z_ion,
         diffusion_dimensions=diffusion_dimensions,

--- a/src/legacy.py
+++ b/src/legacy.py
@@ -1,0 +1,116 @@
+from types import SimpleNamespace
+
+from gemdat import SimulationData, SitesData, load_known_material, plot_all
+from gemdat.plots.jumps import plot_jumps_3d_animation
+from gemdat.rdf import calculate_rdfs, plot_rdf
+
+
+def analyse_md(
+    vasp_xml: str,
+    diff_elem: str,
+    material: str,
+    supercell: tuple[int, int, int] | None = None,
+    equil_time: float = 2.5E-12,
+    diffusion_dimensions: int = 3,
+    z_ion: int = 1,
+    nr_parts: int = 10,
+    dist_collective: float = 4.5,
+    density_resolution: float = 0.2,
+    jump_res: float = 0.1,
+    rdf_res: float = 0.1,
+    rdf_max_dist: int = 10,
+    start_end: tuple[int, int] = (5000, 7500),
+    nr_steps_frame: int = 5,
+) -> tuple[SimulationData, SitesData, SimpleNamespace]:
+    """Analyse md data.
+
+    Parameters
+    ----------
+    vasp_xml : str
+        Simulation data input file
+    diff_elem : str
+        Name of diffusing element
+    material : str
+        Name of known material with sites for diffusing elements
+    supercell : tuple[int, int, int], optional
+        Super cell to apply to the known material
+    equil_time : float, optional
+        Equilibration time in seconds (1e-12 = 1 picosecond)
+    diffusion_dimensions : int, optional
+        Number of diffusion dimensions
+    z_ion : int, optional
+        Ionic charge of diffusing ion
+    nr_parts : int, optional
+        In how many parts to divide your simulation for statistics
+        dist_collective : float, optional
+                Maximum distance for collective motions in Angstrom
+    density_resolution : float, optional
+        Resolution for the diffusing atom density plot in Angstrom
+    jump_res: float
+        Resolution for the number of jumps vs distance plot in Angstrom
+    rdf_res : float, optional
+        Resolution of the rdf bins in Angstrom
+    rdf_max_dist : int, optional
+        Maximal distanbe of the rdf in Angstrom
+    start_end : tuple[int, int], optional
+        The time steps for which to start and end the movie
+    nr_steps_frame : int, optional
+        How many time steps per frame in the movie, increase to get shorter and faster movies
+
+    Returns
+    -------
+    tuple[SimulationData, SitesData, SimpleNamespace]
+        Output data
+    """
+    data = SimulationData.from_vasprun(vasp_xml)
+
+    extras = data.calculate_all(
+        equilibration_steps=1250,
+        diffusing_element=diff_elem,
+        z_ion=z_ion,
+        diffusion_dimensions=diffusion_dimensions,
+        n_parts=nr_parts,
+    )
+
+    sites_structure = load_known_material(material, supercell=supercell)
+
+    sites = SitesData(sites_structure)
+    sites.calculate_all(data=data,
+                        extras=extras,
+                        dist_collective=dist_collective)
+
+    plot_all(data=data,
+             sites=sites,
+             **vars(extras),
+             show=False,
+             jump_res=jump_res)
+
+    rdfs = calculate_rdfs(
+        data=data,
+        sites=sites,
+        diff_coords=extras.diff_coords,
+        n_steps=extras.n_steps,
+        equilibration_steps=extras.equilibration_steps,
+        max_dist=rdf_max_dist,
+        resolution=rdf_res,
+    )
+
+    plot_jumps_3d_animation(
+        data=data,
+        sites=sites,
+        t_start=start_end[0],
+        t_stop=start_end[1],
+        skip=nr_steps_frame,
+        decay=0.05,
+        interval=20,
+    )
+
+    for name, rdf in rdfs.items():
+        plot_rdf(rdf, name=name)
+
+    # trajectory_to_vasp_volume(coords=data.trajectory_coords,
+    # structure=data.structure,
+    # resolution=density_resolution,
+    # filename='volume.vasp')
+
+    return data, sites, extras

--- a/src/legacy.py
+++ b/src/legacy.py
@@ -19,6 +19,7 @@ def analyse_md(
     dist_collective: float = 4.5,
     density_resolution: float = 0.2,
     jump_res: float = 0.1,
+    rdfs: bool = False,
     rdf_res: float = 0.1,
     rdf_max_dist: int = 10,
     start_end: tuple[int, int] = (5000, 7500),
@@ -44,12 +45,14 @@ def analyse_md(
         Ionic charge of diffusing ion
     nr_parts : int, optional
         In how many parts to divide your simulation for statistics
-        dist_collective : float, optional
-                Maximum distance for collective motions in Angstrom
+    dist_collective : float, optional
+        Maximum distance for collective motions in Angstrom
     density_resolution : float, optional
         Resolution for the diffusing atom density plot in Angstrom
-    jump_res: float
+    jump_res: float, optional
         Resolution for the number of jumps vs distance plot in Angstrom
+    rdfs : bool, optional
+        Calculate and show radial distribution functions
     rdf_res : float, optional
         Resolution of the rdf bins in Angstrom
     rdf_max_dist : int, optional
@@ -87,16 +90,6 @@ def analyse_md(
              show=False,
              jump_res=jump_res)
 
-    rdfs = calculate_rdfs(
-        data=data,
-        sites=sites,
-        diff_coords=extras.diff_coords,
-        n_steps=extras.n_steps,
-        equilibration_steps=extras.equilibration_steps,
-        max_dist=rdf_max_dist,
-        resolution=rdf_res,
-    )
-
     plot_jumps_3d_animation(
         data=data,
         sites=sites,
@@ -107,14 +100,24 @@ def analyse_md(
         interval=20,
     )
 
-    for name, rdf in rdfs.items():
-        plot_rdf(rdf, name=name)
-
     filename = 'volume.vasp'
     print(f'Writing trajectory as a volume to `{filename}')
     trajectory_to_vasp_volume(coords=data.trajectory_coords,
                               structure=data.structure,
                               resolution=density_resolution,
                               filename=filename)
+
+    if rdfs:
+        rdf_data = calculate_rdfs(
+            data=data,
+            sites=sites,
+            diff_coords=extras.diff_coords,
+            n_steps=extras.n_steps,
+            equilibration_steps=extras.equilibration_steps,
+            max_dist=rdf_max_dist,
+            resolution=rdf_res,
+        )
+        for name, rdf in rdf_data.items():
+            plot_rdf(rdf, name=name)
 
     return data, sites, extras

--- a/src/sites.py
+++ b/src/sites.py
@@ -45,7 +45,8 @@ class SitesData:
             warnings.warn(f'Lattice mismatch: {this_lattice.parameters} '
                           f'vs. {other_lattice.parameters}')
 
-    def calculate_all(self, data: SimulationData, extras: SimpleNamespace):
+    def calculate_all(self, data: SimulationData, extras: SimpleNamespace,
+                      **kwargs):
         """Calculate all parameters.
 
         Parameters
@@ -110,7 +111,8 @@ class SitesData:
         self.collective, self.coll_jumps, self.n_solo_jumps = self.calculate_collective(
             lattice=data.lattice,
             attempt_freq=extras.attempt_freq,
-            time_step=data.time_step)
+            time_step=data.time_step,
+            **kwargs)
         self.solo_frac = self.n_solo_jumps / len(self.all_transitions)
         self.coll_count = len(self.collective)
 


### PR DESCRIPTION
This PR adds a legacy Python api call (`gemdat.legacy.analyse_md`) function to mimick the matlab code.

```python
from gemdat.legacy import analyse_md

data, sites, extras = analyse_md(
           '~/md-analysis-matlab-example/vasprun.xml',
           diff_elem='Li',
           supercell=(2,1,1),
           material='argyrodite',
           )
```

### Todo

- [x] Figure out why `trajectory_to_vasp_volume` crashes -> seems to be an issue on my side, needed to remove `vasprun.xml.cache`