### PR TITLE
Use `Trajectory` in place of `SimulationData`

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,3 @@
-from .data import SimulationData
 from .io import load_cif, load_known_material
 from .plot import plot, plot_all
 from .sites import SitesData
@@ -9,6 +8,5 @@ __all__ = [
     'load_known_material',
     'plot',
     'plot_all',
-    'SimulationData',
     'SitesData',
 ]

--- a/src/calculate/__init__.py
+++ b/src/calculate/__init__.py
@@ -1,8 +1,10 @@
 from .displacements import Displacements
+from .extras import calculate_all
 from .tracer import Tracer
 from .vibration import Vibration
 
 __all__ = [
+    'calculate_all',
     'Displacements',
     'Vibration',
     'Tracer',

--- a/src/calculate/__init__.py
+++ b/src/calculate/__init__.py
@@ -1,4 +1,5 @@
 from .displacements import Displacements
+from .tracer import Tracer
 from .vibration import Vibration
 
 __all__ = [

--- a/src/calculate/displacements.py
+++ b/src/calculate/displacements.py
@@ -7,19 +7,18 @@ import numpy as np
 if typing.TYPE_CHECKING:
     from types import SimpleNamespace
 
-    from gemdat.trajectory import GemdatTrajectory
+    from gemdat.trajectory import Trajectory
 
 
 class Displacements:
 
     @staticmethod
-    def calculate_all(trajectory: GemdatTrajectory,
-                      extras: SimpleNamespace) -> dict:
+    def calculate_all(trajectory: Trajectory, extras: SimpleNamespace) -> dict:
         """Calculate displacement properties.
 
         Parameters
         ----------
-        trajectory : GemdatTrajectory
+        trajectory : Trajectory
             Input simulation data
         extras : SimpleNamespace
             Extra variables
@@ -45,7 +44,7 @@ class Displacements:
         }
 
     @staticmethod
-    def cell_offsets(trajectory: GemdatTrajectory) -> np.ndarray:
+    def cell_offsets(trajectory: Trajectory) -> np.ndarray:
         """Calculate cell offsets from trajectory starting position.
 
         For example, if a site is at [0, 0, 0.9] -> [0, 0, 0.1]
@@ -53,7 +52,7 @@ class Displacements:
 
         Parameters
         ----------
-        trajectory : GemdatTrajectory
+        trajectory : Trajectory
             Input trajectory
 
         Returns
@@ -95,14 +94,14 @@ class Displacements:
         return np.sqrt(total_displacement)
 
     @staticmethod
-    def displacements(trajectory: GemdatTrajectory) -> np.ndarray:
+    def displacements(trajectory: Trajectory) -> np.ndarray:
         """Calculate displacements from first set of positions.
 
         Corrects for elements jumping to the next unit cell.
 
         Parameters
         ----------
-        trajectory : GemdatTrajectory
+        trajectory : Trajectory
             Input trajectory
 
         Returns

--- a/src/calculate/extras.py
+++ b/src/calculate/extras.py
@@ -1,11 +1,16 @@
+from __future__ import annotations
+
+import typing
 from types import SimpleNamespace
 
 import numpy as np
 
-from .calculate.displacements import Displacements
-from .calculate.tracer import Tracer
-from .calculate.vibration import Vibration
-from .trajectory import Trajectory
+from .displacements import Displacements
+from .tracer import Tracer
+from .vibration import Vibration
+
+if typing.TYPE_CHECKING:
+    from gemdat.trajectory import Trajectory
 
 
 def calculate_all(trajectory: Trajectory,

--- a/src/calculate/tracer.py
+++ b/src/calculate/tracer.py
@@ -1,18 +1,28 @@
+from __future__ import annotations
+
+import typing
+
 import numpy as np
 from pymatgen.core.units import FloatWithUnit
 from scipy.constants import Avogadro, Boltzmann, angstrom, elementary_charge
+
+if typing.TYPE_CHECKING:
+    from types import SimpleNamespace
+
+    from gemdat.trajectory import GemdatTrajectory
 
 
 class Tracer:
 
     @staticmethod
-    def calculate_all(data, extras) -> dict[str, float]:
+    def calculate_all(trajectory: GemdatTrajectory,
+                      extras: SimpleNamespace) -> dict[str, float]:
         """Calculate tracer properties.
 
         Parameters
         ----------
-        data : SimulationData
-            Input simulation data
+        trajectory : GemdatTrajectory
+            Input trajectory
         extras : SimpleNamespace
             Extra variables
 
@@ -21,9 +31,11 @@ class Tracer:
         extras : dict[str, float]
             Dictionary with calculated parameters
         """
+        lattice = trajectory.get_lattice()
+
         total_time = extras.total_time
 
-        volume_ang = data.lattice.volume
+        volume_ang = lattice.volume
         volume_m3 = volume_ang * angstrom**3
 
         particle_density = extras.n_diffusing / volume_m3
@@ -38,7 +50,7 @@ class Tracer:
         # Do they mean the total displacement (i.e. last column)?
         msd = np.mean(extras.diff_displacements[:, -1]**2)  # Angstrom^2
 
-        temperature = data.temperature
+        temperature = trajectory.temperature
 
         # Diffusivity = MSD/(2*dimensions*time)
         tracer_diff = (msd * angstrom**2) / (2 * extras.diffusion_dimensions *

--- a/src/calculate/tracer.py
+++ b/src/calculate/tracer.py
@@ -9,19 +9,19 @@ from scipy.constants import Avogadro, Boltzmann, angstrom, elementary_charge
 if typing.TYPE_CHECKING:
     from types import SimpleNamespace
 
-    from gemdat.trajectory import GemdatTrajectory
+    from gemdat.trajectory import Trajectory
 
 
 class Tracer:
 
     @staticmethod
-    def calculate_all(trajectory: GemdatTrajectory,
+    def calculate_all(trajectory: Trajectory,
                       extras: SimpleNamespace) -> dict[str, float]:
         """Calculate tracer properties.
 
         Parameters
         ----------
-        trajectory : GemdatTrajectory
+        trajectory : Trajectory
             Input trajectory
         extras : SimpleNamespace
             Extra variables

--- a/src/calculate/vibration.py
+++ b/src/calculate/vibration.py
@@ -1,6 +1,15 @@
+from __future__ import annotations
+
+import typing
+
 import numpy as np
 from pymatgen.core.units import FloatWithUnit
 from scipy import signal
+
+if typing.TYPE_CHECKING:
+    from types import SimpleNamespace
+
+    from gemdat.trajectory import GemdatTrajectory
 
 
 def meanfreq(x: np.ndarray, fs: float = 1.0):
@@ -41,13 +50,14 @@ def meanfreq(x: np.ndarray, fs: float = 1.0):
 class Vibration:
 
     @staticmethod
-    def calculate_all(data, extras) -> dict:
+    def calculate_all(trajectory: GemdatTrajectory,
+                      extras: SimpleNamespace) -> dict:
         """Calculate Vibration properties.
 
         Parameters
         ----------
-        data : SimulationData
-            Input simulation data
+        trajectory : GemdatTrajectory
+            Input trajectory
         extras : SimpleNamespace
             Extra variables
 
@@ -56,7 +66,7 @@ class Vibration:
         extras : dict[str, float]
             Dictionary with calculated parameters
         """
-        fs = 1 / data.time_step
+        fs = 1 / trajectory.time_step
 
         speed = Vibration.speed(extras.diff_displacements)
         attempt_freq, attempt_freq_std = Vibration.attempt_frequency(speed,

--- a/src/calculate/vibration.py
+++ b/src/calculate/vibration.py
@@ -9,7 +9,7 @@ from scipy import signal
 if typing.TYPE_CHECKING:
     from types import SimpleNamespace
 
-    from gemdat.trajectory import GemdatTrajectory
+    from gemdat.trajectory import Trajectory
 
 
 def meanfreq(x: np.ndarray, fs: float = 1.0):
@@ -50,13 +50,12 @@ def meanfreq(x: np.ndarray, fs: float = 1.0):
 class Vibration:
 
     @staticmethod
-    def calculate_all(trajectory: GemdatTrajectory,
-                      extras: SimpleNamespace) -> dict:
+    def calculate_all(trajectory: Trajectory, extras: SimpleNamespace) -> dict:
         """Calculate Vibration properties.
 
         Parameters
         ----------
-        trajectory : GemdatTrajectory
+        trajectory : Trajectory
             Input trajectory
         extras : SimpleNamespace
             Extra variables

--- a/src/dashboard/_shared.py
+++ b/src/dashboard/_shared.py
@@ -9,38 +9,39 @@ import streamlit as st
 data_directory = Path(files('gemdat') / 'data')  # type: ignore
 
 
-def get_data_location(filename='vasprun.xml'):
-    if data_location := os.environ.get('VASP_XML'):
-        st.info(f'Got `{data_location}` via environment variable.')
-        return Path(data_location)
+def get_trajectory_location(filename='vasprun.xml'):
+    if trajectory_location := os.environ.get('VASP_XML'):
+        st.info(f'Got `{trajectory_location}` via environment variable.')
+        return Path(trajectory_location)
 
-    data_location = st.session_state.get('data_location', default=filename)
+    trajectory_location = st.session_state.get('trajectory_location',
+                                               default=filename)
 
-    st.markdown(f'Select input `{filename}`')
+    st.markdown('Select input trajectory')
     col1, col2 = st.columns([0.7, 0.3])
     with col1:
-        data_location = st.text_input('filename',
-                                      data_location,
-                                      label_visibility='collapsed')
+        trajectory_location = st.text_input('filename',
+                                            trajectory_location,
+                                            label_visibility='collapsed')
     with col2:
         if st.button('Browse'):
-            data_location = filedialog.askopenfilename()
-            st.session_state.data_location = data_location
+            trajectory_location = filedialog.askopenfilename()
+            st.session_state.trajectory_location = trajectory_location
             st.experimental_rerun()
 
-    if not data_location:
+    if not trajectory_location:
         st.info(f'Select `{filename}` to continue')
         st.stop()
 
-    data_location = Path(data_location).expanduser()
+    trajectory_location = Path(trajectory_location).expanduser()
 
-    if not data_location.exists():
+    if not trajectory_location.exists():
         st.info(
-            f'Could not find `{data_location}`, select `{filename}` to continue'
+            f'Could not find `{trajectory_location}`, select `{filename}` to continue'
         )
         st.stop()
 
-    return data_location
+    return trajectory_location
 
 
 @st.cache_data

--- a/src/dashboard/run.py
+++ b/src/dashboard/run.py
@@ -79,9 +79,8 @@ with st.sidebar:
 number_of_cols = 3  # Number of figure columns
 
 with st.spinner('Processing trajectory...'):
-    extra = calculate_all(trajectory,
-                          equilibration_steps=equilibration_steps,
-                          diffusing_element=diffusing_element)
+    trajectory = trajectory[equilibration_steps:]
+    extra = calculate_all(trajectory, diffusing_element=diffusing_element)
 
 col1, col2, col3 = st.columns(3)
 

--- a/src/dashboard/run.py
+++ b/src/dashboard/run.py
@@ -4,7 +4,7 @@ from gemdat import SitesData, __version__, plot_all
 from gemdat.data import calculate_all
 from gemdat.io import get_list_of_known_materials, load_known_material
 from gemdat.rdf import calculate_rdfs, plot_rdf
-from gemdat.trajectory import GemdatTrajectory
+from gemdat.trajectory import Trajectory
 from gemdat.utils import is_lattice_similar
 
 st.set_page_config(
@@ -33,7 +33,7 @@ with st.sidebar:
 
 @st.cache_data
 def _load_trajectory(trajectory_location):
-    return GemdatTrajectory.from_vasprun(trajectory_location)
+    return Trajectory.from_vasprun(trajectory_location)
 
 
 with st.spinner('Loading your trajectory data, this might take a while'):

--- a/src/dashboard/run.py
+++ b/src/dashboard/run.py
@@ -1,7 +1,7 @@
 import streamlit as st
 from _shared import add_sidebar_logo, get_trajectory_location
 from gemdat import SitesData, __version__, plot_all
-from gemdat.data import calculate_all
+from gemdat.calculate import calculate_all
 from gemdat.io import get_list_of_known_materials, load_known_material
 from gemdat.rdf import calculate_rdfs, plot_rdf
 from gemdat.trajectory import Trajectory

--- a/src/data.py
+++ b/src/data.py
@@ -5,10 +5,10 @@ import numpy as np
 from .calculate.displacements import Displacements
 from .calculate.tracer import Tracer
 from .calculate.vibration import Vibration
-from .trajectory import GemdatTrajectory
+from .trajectory import Trajectory
 
 
-def calculate_all(trajectory: GemdatTrajectory,
+def calculate_all(trajectory: Trajectory,
                   *,
                   diffusing_element: str,
                   known_structure: str | None = None,
@@ -21,7 +21,7 @@ def calculate_all(trajectory: GemdatTrajectory,
 
     Parameters
     ----------
-    trajectory : GemdatTrajectory
+    trajectory : Trajectory
         Input trajectory coordinates
     diffusing_element : str
         Name of the diffusing element
@@ -59,8 +59,7 @@ def calculate_all(trajectory: GemdatTrajectory,
     return extras
 
 
-def _add_shared_variables(trajectory: GemdatTrajectory,
-                          extras: SimpleNamespace):
+def _add_shared_variables(trajectory: Trajectory, extras: SimpleNamespace):
     """Add common shared variables to extras namespace."""
     extras.n_diffusing = sum(
         [e.name == extras.diffusing_element for e in trajectory.species])

--- a/src/data.py
+++ b/src/data.py
@@ -12,7 +12,6 @@ def calculate_all(trajectory: Trajectory,
                   *,
                   diffusing_element: str,
                   known_structure: str | None = None,
-                  equilibration_steps: int = 1250,
                   diffusion_dimensions: int = 3,
                   z_ion: float = 1.0,
                   n_parts: int = 10,
@@ -27,8 +26,6 @@ def calculate_all(trajectory: Trajectory,
         Name of the diffusing element
     structure : str | None
         Path to cif file or name of known structure
-    equilibration_steps : int
-        Number of equilibration steps
     diffusion_dimensions : int
         Number of diffusion dimensions
     z_ion : float
@@ -41,14 +38,11 @@ def calculate_all(trajectory: Trajectory,
     extras = SimpleNamespace(
         diffusing_element=diffusing_element,
         known_structure=known_structure,
-        equilibration_steps=equilibration_steps,
         diffusion_dimensions=diffusion_dimensions,
         z_ion=z_ion,
         n_parts=n_parts,
         dist_collective=dist_collective,
     )
-    trajectory = trajectory[equilibration_steps:]
-
     _add_shared_variables(trajectory, extras)
 
     extras.__dict__.update(

--- a/src/data.py
+++ b/src/data.py
@@ -1,11 +1,6 @@
-import pickle
-from dataclasses import dataclass
-from pathlib import Path
 from types import SimpleNamespace
-from typing import Optional
 
 import numpy as np
-from pymatgen.io import vasp
 
 from .calculate.displacements import Displacements
 from .calculate.tracer import Tracer
@@ -13,165 +8,68 @@ from .calculate.vibration import Vibration
 from .trajectory import GemdatTrajectory
 
 
-@dataclass(slots=True)
-class SimulationData:
-    """Dataclass to store simulation data."""
+def calculate_all(trajectory: GemdatTrajectory,
+                  *,
+                  diffusing_element: str,
+                  known_structure: str | None = None,
+                  equilibration_steps: int = 1250,
+                  diffusion_dimensions: int = 3,
+                  z_ion: float = 1.0,
+                  n_parts: int = 10,
+                  dist_collective: float = 4.5):
+    """Calculate extra parameters and return them as a simple namespace.
 
-    trajectory: GemdatTrajectory
+    Parameters
+    ----------
+    trajectory : GemdatTrajectory
+        Input trajectory coordinates
+    diffusing_element : str
+        Name of the diffusing element
+    structure : str | None
+        Path to cif file or name of known structure
+    equilibration_steps : int
+        Number of equilibration steps
+    diffusion_dimensions : int
+        Number of diffusion dimensions
+    z_ion : float
+        Ionic charge of the diffusing ion
+    n_parts : int
+        In how many parts to divide your simulation for statistics
+    dist_collective : float
+        Maximum distance for collective motions in Angstrom
+    """
+    extras = SimpleNamespace(
+        diffusing_element=diffusing_element,
+        known_structure=known_structure,
+        equilibration_steps=equilibration_steps,
+        diffusion_dimensions=diffusion_dimensions,
+        z_ion=z_ion,
+        n_parts=n_parts,
+        dist_collective=dist_collective,
+    )
+    trajectory = trajectory[equilibration_steps:]
 
-    @classmethod
-    def from_cache(cls, cache: str | Path):
-        """Load data from cache using pickle.
+    _add_shared_variables(trajectory, extras)
 
-        Parameters
-        ----------
-        cache : Path
-            Name of cache file
+    extras.__dict__.update(
+        Displacements.calculate_all(trajectory, extras=extras))
+    extras.__dict__.update(Vibration.calculate_all(trajectory, extras=extras))
+    extras.__dict__.update(Tracer.calculate_all(trajectory, extras=extras))
 
-        Returns
-        -------
-        data : SimulationData
-            Dataclass with simulation data
-        """
-        with open(cache, 'rb') as f:
-            data = pickle.load(f)
-        return cls(**data)
+    return extras
 
-    def to_cache(self, cache: str | Path):
-        """Dump data to cache using pickle.
 
-        Parameters
-        ----------
-        cache : Path
-            Name of cache file
-        """
-        # convert to dict without object conversion
-        with open(cache, 'wb') as f:
-            pickle.dump(self.dict, f)
+def _add_shared_variables(trajectory: GemdatTrajectory,
+                          extras: SimpleNamespace):
+    """Add common shared variables to extras namespace."""
+    extras.n_diffusing = sum(
+        [e.name == extras.diffusing_element for e in trajectory.species])
+    extras.n_steps = len(trajectory)
 
-    @property
-    def dict(self) -> dict:
-        """Dict is an alternative for dataclasses.asdict.
+    extras.total_time = extras.n_steps * trajectory.time_step
 
-        dataclasses.asdict has a problem with pymatgenclasses, so we do
-        a more superficial conversion
-        """
-        return {
-            slotname: getattr(self, slotname)
-            for slotname in self.__slots__  # type: ignore
-        }
+    diffusing_idx = np.argwhere([
+        e.name == extras.diffusing_element for e in trajectory.species
+    ]).flatten()
 
-    def calculate_all(self,
-                      *,
-                      diffusing_element: str,
-                      known_structure: str | None = None,
-                      equilibration_steps: int = 1250,
-                      diffusion_dimensions: int = 3,
-                      z_ion: float = 1.0,
-                      n_parts: int = 10,
-                      dist_collective: float = 4.5):
-        """Calculate extra parameters and return them as a simple namespace.
-
-        Parameters
-        ----------
-        diffusing_element : str
-            Name of the diffusing element
-        structure : str | None
-            Path to cif file or name of known structure
-        equilibration_steps : int
-            Number of equilibration steps
-        diffusion_dimensions : int
-            Number of diffusion dimensions
-        z_ion : float
-            Ionic charge of the diffusing ion
-        n_parts : int
-            In how many parts to divide your simulation for statistics
-        dist_collective : float
-            Maximum distance for collective motions in Angstrom
-        """
-        extras = SimpleNamespace(
-            diffusing_element=diffusing_element,
-            known_structure=known_structure,
-            equilibration_steps=equilibration_steps,
-            diffusion_dimensions=diffusion_dimensions,
-            z_ion=z_ion,
-            n_parts=n_parts,
-            dist_collective=dist_collective,
-        )
-
-        self._add_shared_variables(extras)
-
-        extras.__dict__.update(Displacements.calculate_all(self,
-                                                           extras=extras))
-        extras.__dict__.update(Vibration.calculate_all(self, extras=extras))
-        extras.__dict__.update(Tracer.calculate_all(self, extras=extras))
-
-        return extras
-
-    def _add_shared_variables(self, extras: SimpleNamespace):
-        """Add common shared variables to extras namespace."""
-        extras.n_diffusing = sum(
-            [e.name == extras.diffusing_element for e in self.species])
-        extras.n_steps = len(
-            self.trajectory_coords) - extras.equilibration_steps
-
-        extras.total_time = extras.n_steps * self.time_step
-
-        diffusing_idx = np.argwhere([
-            e.name == extras.diffusing_element for e in self.species
-        ]).flatten()
-
-        extras.diff_coords = self.trajectory_coords[
-            extras.equilibration_steps:, diffusing_idx, :]
-
-    @classmethod
-    def from_vasprun(cls,
-                     xml_file: str | Path,
-                     cache: Optional[str | Path] = None):
-        """Load data from vasprun.xml.
-
-        Parameters
-        ----------
-        xml_file : Path
-            Path to vasprun.xml
-        cache : Optional[Path], optional
-            Path to cache data for vasprun.xml
-
-        Returns
-        -------
-        data : Data
-            Dataclass with simulation data
-        """
-
-        if not cache:
-            cache = Path(str(xml_file) + '.cache')
-
-        if Path(cache).exists():
-            try:
-                return cls.from_cache(cache)
-            except Exception as e:
-                print(e)
-                print('Error reading from cache, reading full VaspRun')
-
-        run = vasp.Vasprun(
-            xml_file,
-            parse_dos=False,
-            parse_eigen=False,
-            parse_projected_eigen=False,
-            parse_potcar_file=False,
-        )
-
-        trajectory = GemdatTrajectory.from_structures(
-            run.structures,
-            constant_lattice=False,
-            time_step=run.parameters['POTIM'] * 1e-15,
-        )
-        trajectory.to_positions()
-        trajectory.temperature = run.parameters['TEBEG']
-
-        ret = cls(trajectory=trajectory)
-
-        if cache:
-            ret.to_cache(cache)
-
-        return ret
+    extras.diff_coords = trajectory.coords[:, diffusing_idx, :]

--- a/src/legacy.py
+++ b/src/legacy.py
@@ -73,9 +73,10 @@ def analyse_md(
 
     equilibration_steps = round(equil_time / trajectory.time_step)
 
+    trajectory = trajectory[equilibration_steps:]
+
     extras = calculate_all(
         trajectory,
-        equilibration_steps=equilibration_steps,
         diffusing_element=diff_elem,
         z_ion=z_ion,
         diffusion_dimensions=diffusion_dimensions,

--- a/src/legacy.py
+++ b/src/legacy.py
@@ -108,7 +108,9 @@ def analyse_md(
 
     filename = 'volume.vasp'
     print(f'Writing trajectory as a volume to `{filename}')
-    trajectory_to_vasp_volume(trajectory=trajectory,
+
+    trajectory_to_vasp_volume(coords=extras.diff_coords,
+                              structure=trajectory.get_structure(0),
                               resolution=density_resolution,
                               filename=filename)
 

--- a/src/legacy.py
+++ b/src/legacy.py
@@ -1,7 +1,7 @@
 from types import SimpleNamespace
 
 from gemdat import SitesData, load_known_material, plot_all
-from gemdat.data import calculate_all
+from gemdat.calculate import calculate_all
 from gemdat.plots.jumps import plot_jumps_3d_animation
 from gemdat.rdf import calculate_rdfs, plot_rdf
 from gemdat.trajectory import Trajectory

--- a/src/legacy.py
+++ b/src/legacy.py
@@ -4,7 +4,7 @@ from gemdat import SitesData, load_known_material, plot_all
 from gemdat.data import calculate_all
 from gemdat.plots.jumps import plot_jumps_3d_animation
 from gemdat.rdf import calculate_rdfs, plot_rdf
-from gemdat.trajectory import GemdatTrajectory
+from gemdat.trajectory import Trajectory
 from gemdat.volume import trajectory_to_vasp_volume
 
 
@@ -26,7 +26,7 @@ def analyse_md(
     rdf_max_dist: int = 10,
     start_end: tuple[int, int] = (5000, 7500),
     nr_steps_frame: int = 5,
-) -> tuple[GemdatTrajectory, SitesData, SimpleNamespace]:
+) -> tuple[Trajectory, SitesData, SimpleNamespace]:
     """Analyse md data.
 
     Parameters
@@ -69,7 +69,7 @@ def analyse_md(
     tuple[SimulationData, SitesData, SimpleNamespace]
         Output data
     """
-    trajectory = GemdatTrajectory.from_vasprun(vasp_xml)
+    trajectory = Trajectory.from_vasprun(vasp_xml)
 
     equilibration_steps = round(equil_time / trajectory.time_step)
 

--- a/src/legacy.py
+++ b/src/legacy.py
@@ -1,8 +1,10 @@
 from types import SimpleNamespace
 
-from gemdat import SimulationData, SitesData, load_known_material, plot_all
+from gemdat import SitesData, load_known_material, plot_all
+from gemdat.data import calculate_all
 from gemdat.plots.jumps import plot_jumps_3d_animation
 from gemdat.rdf import calculate_rdfs, plot_rdf
+from gemdat.trajectory import GemdatTrajectory
 from gemdat.volume import trajectory_to_vasp_volume
 
 
@@ -24,7 +26,7 @@ def analyse_md(
     rdf_max_dist: int = 10,
     start_end: tuple[int, int] = (5000, 7500),
     nr_steps_frame: int = 5,
-) -> tuple[SimulationData, SitesData, SimpleNamespace]:
+) -> tuple[GemdatTrajectory, SitesData, SimpleNamespace]:
     """Analyse md data.
 
     Parameters
@@ -67,11 +69,12 @@ def analyse_md(
     tuple[SimulationData, SitesData, SimpleNamespace]
         Output data
     """
-    data = SimulationData.from_vasprun(vasp_xml)
+    trajectory = GemdatTrajectory.from_vasprun(vasp_xml)
 
-    equilibration_steps = round(equil_time / data.time_step)
+    equilibration_steps = round(equil_time / trajectory.time_step)
 
-    extras = data.calculate_all(
+    extras = calculate_all(
+        trajectory,
         equilibration_steps=equilibration_steps,
         diffusing_element=diff_elem,
         z_ion=z_ion,
@@ -82,18 +85,18 @@ def analyse_md(
     sites_structure = load_known_material(material, supercell=supercell)
 
     sites = SitesData(sites_structure)
-    sites.calculate_all(data=data,
+    sites.calculate_all(trajectory=trajectory,
                         extras=extras,
                         dist_collective=dist_collective)
 
-    plot_all(data=data,
+    plot_all(trajectory=trajectory,
              sites=sites,
              **vars(extras),
              show=False,
              jump_res=jump_res)
 
     plot_jumps_3d_animation(
-        data=data,
+        trajectory=trajectory,
         sites=sites,
         t_start=start_end[0],
         t_stop=start_end[1],
@@ -104,22 +107,20 @@ def analyse_md(
 
     filename = 'volume.vasp'
     print(f'Writing trajectory as a volume to `{filename}')
-    trajectory_to_vasp_volume(coords=data.trajectory_coords,
-                              structure=data.structure,
+    trajectory_to_vasp_volume(trajectory=trajectory,
                               resolution=density_resolution,
                               filename=filename)
 
     if rdfs:
         rdf_data = calculate_rdfs(
-            data=data,
+            trajectory=trajectory,
             sites=sites,
             diff_coords=extras.diff_coords,
             n_steps=extras.n_steps,
-            equilibration_steps=extras.equilibration_steps,
             max_dist=rdf_max_dist,
             resolution=rdf_res,
         )
         for name, rdf in rdf_data.items():
             plot_rdf(rdf, name=name)
 
-    return data, sites, extras
+    return trajectory, sites, extras

--- a/src/plot.py
+++ b/src/plot.py
@@ -4,18 +4,18 @@ import gemdat.plots as available_plots
 import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
 
-from .trajectory import GemdatTrajectory
+from .trajectory import Trajectory
 
 
 def plot(plots: Union[List[str], str],
-         trajectory: Optional[GemdatTrajectory] = None,
+         trajectory: Optional[Trajectory] = None,
          show: bool = True,
          **kwargs) -> List[Figure]:
     """Display all or a selection of plots.
 
     Parameters
     ----------
-    trajectory : GemdatTrajectory
+    trajectory : Trajectory
         Input trajectory
     plots : Union[List[str],str]
         List of plot names, or just a plot name for the plot you want.
@@ -51,7 +51,7 @@ def plot_all(**kwargs) -> List[Figure]:
 
     Parameters
     ----------
-    data : GemdatTrajectory
+    data : Trajectory
         data
     kwargs :
         kwargs

--- a/src/plot.py
+++ b/src/plot.py
@@ -4,11 +4,11 @@ import gemdat.plots as available_plots
 import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
 
-from .data import SimulationData
+from .trajectory import GemdatTrajectory
 
 
 def plot(plots: Union[List[str], str],
-         data: Optional[SimulationData] = None,
+         data: Optional[GemdatTrajectory] = None,
          show: bool = True,
          **kwargs) -> List[Figure]:
     """Main plotting function of gemdat. it takes two mandatory arguments:
@@ -18,7 +18,7 @@ def plot(plots: Union[List[str], str],
 
     Parameters
     ----------
-    data : SimulationData
+    data : GemdatTrajectory
         data
     plots : Union[List[str],str]
         plots
@@ -58,7 +58,7 @@ def plot_all(**kwargs) -> List[Figure]:
 
     Parameters
     ----------
-    data : SimulationData
+    data : GemdatTrajectory
         data
     kwargs :
         kwargs

--- a/src/plot.py
+++ b/src/plot.py
@@ -1,10 +1,13 @@
-from typing import List, Optional, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List, Optional, Union
 
 import gemdat.plots as available_plots
 import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
 
-from .trajectory import Trajectory
+if TYPE_CHECKING:
+    from .trajectory import Trajectory
 
 
 def plot(plots: Union[List[str], str],

--- a/src/plot.py
+++ b/src/plot.py
@@ -15,10 +15,12 @@ def plot(plots: Union[List[str], str],
 
     Parameters
     ----------
-    trajectory : Trajectory
-        Input trajectory
     plots : Union[List[str],str]
         List of plot names, or just a plot name for the plot you want.
+    trajectory : Optional[Trajectory]
+        Input trajectory
+    show : bool
+        Show plots if True
     kwargs : dict
         Optional arguments which are passed down to the plotting functions.
 
@@ -27,8 +29,6 @@ def plot(plots: Union[List[str], str],
     Figure:
         A list of matplotlib figures
     """
-
-    # Convert plots to list, if it is not already a list
     if not isinstance(plots, list):
         plots = [plots]
 
@@ -45,20 +45,17 @@ def plot(plots: Union[List[str], str],
     return figures
 
 
-def plot_all(**kwargs) -> List[Figure]:
-    """The Plot All function finds out which plots are available for plotting,
-    and plots those.
+def plot_all(**kwargs) -> list[Figure]:
+    """Display all available plots.
 
     Parameters
     ----------
-    data : Trajectory
-        data
-    kwargs :
-        kwargs
+    kwargs : dict
+        Keyword arguments passed down to plotting functions
 
     Returns
     -------
-    Figure:
+    list[Figure]:
         A list of matplotlib figures
     """
     return plot(plots=available_plots.__all__, **kwargs)

--- a/src/plot.py
+++ b/src/plot.py
@@ -8,22 +8,19 @@ from .trajectory import GemdatTrajectory
 
 
 def plot(plots: Union[List[str], str],
-         data: Optional[GemdatTrajectory] = None,
+         trajectory: Optional[GemdatTrajectory] = None,
          show: bool = True,
          **kwargs) -> List[Figure]:
-    """Main plotting function of gemdat. it takes two mandatory arguments:
-
-    - plots, a list of plot names, or just a plot name for the plot you want.
-    - Optional arguments which are passed down to the plotting functions.
+    """Display all or a selection of plots.
 
     Parameters
     ----------
-    data : GemdatTrajectory
-        data
+    trajectory : GemdatTrajectory
+        Input trajectory
     plots : Union[List[str],str]
-        plots
-    kwargs :
-        kwargs
+        List of plot names, or just a plot name for the plot you want.
+    kwargs : dict
+        Optional arguments which are passed down to the plotting functions.
 
     Returns
     -------
@@ -35,15 +32,11 @@ def plot(plots: Union[List[str], str],
     if not isinstance(plots, list):
         plots = [plots]
 
-    # extract data if present, but prioritise kwargs
-    if data:
-        kwargs = {**data.dict, **kwargs}
-
     figures = []
 
     for plot in plots:
         plot_function = getattr(available_plots, plot)
-        figure = plot_function(data=data, **kwargs)
+        figure = plot_function(trajectory=trajectory, **kwargs)
         figures.append(figure)
 
     if show:

--- a/src/plots/displacements.py
+++ b/src/plots/displacements.py
@@ -1,6 +1,6 @@
 import matplotlib.pyplot as plt
 import numpy as np
-from gemdat.trajectory import GemdatTrajectory
+from gemdat.trajectory import Trajectory
 
 
 def plot_displacement_per_site(*, diff_displacements: np.ndarray, **kwargs):
@@ -24,7 +24,7 @@ def plot_displacement_per_site(*, diff_displacements: np.ndarray, **kwargs):
 
 
 def plot_displacement_per_element(*, displacements: np.ndarray,
-                                  trajectory: GemdatTrajectory, **kwargs):
+                                  trajectory: Trajectory, **kwargs):
     """Plot displacement per element.
 
     Parameters

--- a/src/plots/displacements.py
+++ b/src/plots/displacements.py
@@ -1,6 +1,6 @@
 import matplotlib.pyplot as plt
 import numpy as np
-from pymatgen.core import Structure
+from gemdat.trajectory import GemdatTrajectory
 
 
 def plot_displacement_per_site(*, diff_displacements: np.ndarray, **kwargs):
@@ -23,9 +23,8 @@ def plot_displacement_per_site(*, diff_displacements: np.ndarray, **kwargs):
     return fig
 
 
-def plot_displacement_per_element(structure: Structure,
-                                  displacements: np.ndarray, species,
-                                  **kwargs):
+def plot_displacement_per_element(*, displacements: np.ndarray,
+                                  trajectory: GemdatTrajectory, **kwargs):
     """Plot displacement per element.
 
     Parameters
@@ -39,6 +38,9 @@ def plot_displacement_per_element(structure: Structure,
     from collections import defaultdict
 
     grouped = defaultdict(list)
+
+    trajectory.get_structure(0)
+    species = trajectory.species
 
     for specie, displacement in zip(species, displacements):
         grouped[specie.name].append(displacement)

--- a/src/plots/jumps.py
+++ b/src/plots/jumps.py
@@ -10,11 +10,11 @@ from pymatgen.electronic_structure import plotter
 
 if TYPE_CHECKING:
     from gemdat import SitesData
-    from gemdat.trajectory import GemdatTrajectory
+    from gemdat.trajectory import Trajectory
 
 
 def plot_jumps_vs_distance(*,
-                           trajectory: GemdatTrajectory,
+                           trajectory: Trajectory,
                            sites: SitesData,
                            jump_res: float = 0.1,
                            **kwargs) -> plt.Figure:
@@ -22,7 +22,7 @@ def plot_jumps_vs_distance(*,
 
     Parameters
     ----------
-    trajectory : GemdatTrajectory
+    trajectory : Trajectory
         Input trajectory
     sites : SitesData
         Input sites data
@@ -59,7 +59,7 @@ def plot_jumps_vs_distance(*,
 
 
 def plot_jumps_vs_time(*,
-                       trajectory: GemdatTrajectory,
+                       trajectory: Trajectory,
                        sites: SitesData,
                        binsize: int = 500,
                        **kwargs) -> plt.Figure:
@@ -67,7 +67,7 @@ def plot_jumps_vs_time(*,
 
     Parameters
     ----------
-    trajectory : GemdatTrajectory
+    trajectory : Trajectory
         Input trajectory
     sites : SitesData
         Input sites data
@@ -93,13 +93,13 @@ def plot_jumps_vs_time(*,
     return fig
 
 
-def plot_collective_jumps(*, trajectory: GemdatTrajectory, sites: SitesData,
+def plot_collective_jumps(*, trajectory: Trajectory, sites: SitesData,
                           **kwargs) -> plt.Figure:
     """Plot collective jumps per jump-type combination.
 
     Parameters
     ----------
-    trajectory : GemdatTrajectory
+    trajectory : Trajectory
         Input trajectory
     sites : SitesData
         Input sites data
@@ -124,13 +124,13 @@ def plot_collective_jumps(*, trajectory: GemdatTrajectory, sites: SitesData,
     return fig
 
 
-def plot_jumps_3d(*, trajectory: GemdatTrajectory, sites: SitesData,
+def plot_jumps_3d(*, trajectory: Trajectory, sites: SitesData,
                   **kwargs) -> plt.Figure:
     """Plot jumps in 3D.
 
     Parameters
     ----------
-    trajectory : GemdatTrajectory
+    trajectory : Trajectory
         Input trajectory
     sites : SitesData
         Input sites data
@@ -208,7 +208,7 @@ def plot_jumps_3d(*, trajectory: GemdatTrajectory, sites: SitesData,
 
 
 def plot_jumps_3d_animation(*,
-                            trajectory: GemdatTrajectory,
+                            trajectory: Trajectory,
                             sites: SitesData,
                             t_start: int,
                             t_stop: int,
@@ -226,7 +226,7 @@ def plot_jumps_3d_animation(*,
 
     Parameters
     ----------
-    trajectory : GemdatTrajectory
+    trajectory : Trajectory
         Input trajectory
     sites : SitesData
         Input sites data

--- a/src/plots/jumps.py
+++ b/src/plots/jumps.py
@@ -9,11 +9,12 @@ from matplotlib import colormaps
 from pymatgen.electronic_structure import plotter
 
 if TYPE_CHECKING:
-    from gemdat import SimulationData, SitesData
+    from gemdat import SitesData
+    from gemdat.trajectory import GemdatTrajectory
 
 
 def plot_jumps_vs_distance(*,
-                           data: SimulationData,
+                           trajectory: GemdatTrajectory,
                            sites: SitesData,
                            jump_res: float = 0.1,
                            **kwargs) -> plt.Figure:
@@ -21,6 +22,8 @@ def plot_jumps_vs_distance(*,
 
     Parameters
     ----------
+    trajectory : GemdatTrajectory
+        Input trajectory
     sites : SitesData
         Input sites data
     jump_res : float, optional
@@ -30,7 +33,7 @@ def plot_jumps_vs_distance(*,
     -------
     plt.Figure
     """
-    lattice = data.lattice
+    lattice = trajectory.get_lattice()
     structure = sites.structure
     pdist = lattice.get_all_distances(structure.frac_coords,
                                       structure.frac_coords)
@@ -56,21 +59,18 @@ def plot_jumps_vs_distance(*,
 
 
 def plot_jumps_vs_time(*,
-                       data: SimulationData,
+                       trajectory: GemdatTrajectory,
                        sites: SitesData,
-                       n_steps: int,
                        binsize: int = 500,
                        **kwargs) -> plt.Figure:
     """Plot jumps vs. distance histogram.
 
     Parameters
     ----------
-    data : SimulationData
-        Input simulation data
+    trajectory : GemdatTrajectory
+        Input trajectory
     sites : SitesData
         Input sites data
-    n_steps : int
-        Total number of time steps
     binsize : int, optional
         Width of each bin in number of time steps
 
@@ -79,6 +79,7 @@ def plot_jumps_vs_time(*,
     -------
     plt.Figure
     """
+    n_steps = len(trajectory)
     bins = np.arange(0, n_steps + binsize, binsize)
 
     fig, ax = plt.subplots()
@@ -92,14 +93,14 @@ def plot_jumps_vs_time(*,
     return fig
 
 
-def plot_collective_jumps(*, data: SimulationData, sites: SitesData,
+def plot_collective_jumps(*, trajectory: GemdatTrajectory, sites: SitesData,
                           **kwargs) -> plt.Figure:
     """Plot collective jumps per jump-type combination.
 
     Parameters
     ----------
-    data : SimulationData
-        Input simulation data
+    trajectory : GemdatTrajectory
+        Input trajectory
     sites : SitesData
         Input sites data
 
@@ -123,14 +124,14 @@ def plot_collective_jumps(*, data: SimulationData, sites: SitesData,
     return fig
 
 
-def plot_jumps_3d(*, data: SimulationData, sites: SitesData,
+def plot_jumps_3d(*, trajectory: GemdatTrajectory, sites: SitesData,
                   **kwargs) -> plt.Figure:
     """Plot jumps in 3D.
 
     Parameters
     ----------
-    data : SimulationData
-        Input simulation data
+    trajectory : GemdatTrajectory
+        Input trajectory
     sites : SitesData
         Input sites data
 
@@ -149,7 +150,7 @@ def plot_jumps_3d(*, data: SimulationData, sites: SitesData,
             yield from zip(self.labels, self.coords)
 
     coords = sites.structure.frac_coords
-    lattice = data.structure.lattice
+    lattice = trajectory.get_lattice()
 
     fig = plt.figure()
     ax = fig.add_subplot(projection='3d')
@@ -207,7 +208,7 @@ def plot_jumps_3d(*, data: SimulationData, sites: SitesData,
 
 
 def plot_jumps_3d_animation(*,
-                            data: SimulationData,
+                            trajectory: GemdatTrajectory,
                             sites: SitesData,
                             t_start: int,
                             t_stop: int,
@@ -225,8 +226,8 @@ def plot_jumps_3d_animation(*,
 
     Parameters
     ----------
-    data : SimulationData
-        Input simulation data
+    trajectory : GemdatTrajectory
+        Input trajectory
     sites : SitesData
         Input sites data
     t_start : int
@@ -257,7 +258,7 @@ def plot_jumps_3d_animation(*,
             yield from zip(self.labels, self.coords)
 
     coords = sites.structure.frac_coords
-    lattice = data.structure.lattice
+    lattice = trajectory.get_lattice()
 
     color_from = colormaps['Set1'].colors
     color_to = colormaps['Pastel1'].colors

--- a/src/rdf.py
+++ b/src/rdf.py
@@ -1,9 +1,15 @@
+from __future__ import annotations
+
+import typing
 from collections import defaultdict
 
 import numpy as np
-from gemdat import SimulationData, SitesData
+from gemdat import SitesData
 from pymatgen.core import Structure
 from rich.progress import track
+
+if typing.TYPE_CHECKING:
+    from gemdat.trajectory import GemdatTrajectory
 
 
 def _uniqify_labels(arr, labels: list[str]) -> np.ndarray:
@@ -40,7 +46,7 @@ def _get_states(labels: list[str]) -> dict[int, str]:
     return states
 
 
-def _get_states_array(sites: SimulationData, labels: list[str]) -> np.ndarray:
+def _get_states_array(sites: SitesData, labels: list[str]) -> np.ndarray:
     """Helper function to generate integer array of transition states."""
     atom_sites = _uniqify_labels(sites.atom_sites, labels)
     atom_sites_from = _uniqify_labels(sites.atom_sites_from, labels)
@@ -64,26 +70,23 @@ def _get_symbol_indices(structure: Structure) -> dict[str, np.ndarray]:
 
 def calculate_rdfs(
         *,
-        data: SimulationData,
+        trajectory: GemdatTrajectory,
         sites: SitesData,
         diff_coords: np.ndarray,
         n_steps: int,
-        equilibration_steps: int,
         max_dist: float = 5.0,
         resolution: float = 0.1) -> dict[str, dict[str, np.ndarray]]:
     """
     Parameters
     ----------
-    data : SimulationData
-        Input simulation data
+    trajectory : GemdatTrajectory
+        Input trajectory
     sites : SitesData
         Input sites data
     diff_coords : np.ndarray
         Input coordinates for diffusing element (extras)
     n_steps : int
         Total number of simulation steps (extras)
-    equilibration_steps : int
-        Number of equilibration steps (extras)
     max_dist : float, optional
         Max distance for rdf calculation
     resolution : float, optional
@@ -94,10 +97,10 @@ def calculate_rdfs(
     rdfs : dict[str, np.ndarray]
         Dictionary with rdf arrays per symbol
     """
-    structure = data.structure
-    lattice = structure.lattice
+    structure = trajectory.get_structure(0)
+    lattice = trajectory.get_lattice()
 
-    coords = data.trajectory_coords[equilibration_steps:]
+    coords = trajectory.coords
 
     states2str = _get_states(sites.structure.labels)
     states_array = _get_states_array(sites, sites.structure.labels)

--- a/src/rdf.py
+++ b/src/rdf.py
@@ -9,7 +9,7 @@ from pymatgen.core import Structure
 from rich.progress import track
 
 if typing.TYPE_CHECKING:
-    from gemdat.trajectory import GemdatTrajectory
+    from gemdat.trajectory import Trajectory
 
 
 def _uniqify_labels(arr, labels: list[str]) -> np.ndarray:
@@ -70,7 +70,7 @@ def _get_symbol_indices(structure: Structure) -> dict[str, np.ndarray]:
 
 def calculate_rdfs(
         *,
-        trajectory: GemdatTrajectory,
+        trajectory: Trajectory,
         sites: SitesData,
         diff_coords: np.ndarray,
         n_steps: int,
@@ -79,7 +79,7 @@ def calculate_rdfs(
     """
     Parameters
     ----------
-    trajectory : GemdatTrajectory
+    trajectory : Trajectory
         Input trajectory
     sites : SitesData
         Input sites data

--- a/src/sites.py
+++ b/src/sites.py
@@ -15,7 +15,7 @@ from .utils import bfill, ffill, is_lattice_similar
 if typing.TYPE_CHECKING:
     from types import SimpleNamespace
 
-    from gemdat.trajectory import GemdatTrajectory
+    from gemdat.trajectory import Trajectory
 
 NOSITE = -1
 
@@ -46,13 +46,13 @@ class SitesData:
             warnings.warn(f'Lattice mismatch: {this_lattice.parameters} '
                           f'vs. {other_lattice.parameters}')
 
-    def calculate_all(self, trajectory: GemdatTrajectory,
-                      extras: SimpleNamespace, **kwargs):
+    def calculate_all(self, trajectory: Trajectory, extras: SimpleNamespace,
+                      **kwargs):
         """Calculate all parameters.
 
         Parameters
         ----------
-        trajectory : GemdatTrajectory
+        trajectory : Trajectory
             Input trajectory
         extras : SimpleNamespace
             Extra parameters
@@ -123,14 +123,14 @@ class SitesData:
         """
         return ['->'.join(key) for key in self.jumps]
 
-    def calculate_dist_close(self, trajectory: GemdatTrajectory,
+    def calculate_dist_close(self, trajectory: Trajectory,
                              vibration_amplitude: float):
         """Calculate tolerance wihin which atoms are considered to be close to
         a site.
 
         Parameters
         ----------
-        trajectory : GemdatTrajectory
+        trajectory : Trajectory
             Input trajectory
         vibration_amplitude : float
             Vibration amplitude
@@ -174,7 +174,7 @@ class SitesData:
 
         return dist_close
 
-    def calculate_atom_sites(self, trajectory: GemdatTrajectory,
+    def calculate_atom_sites(self, trajectory: Trajectory,
                              diff_coords: np.ndarray) -> np.ndarray:
         """Calculate nearest site for each atom coordinate.
 
@@ -184,7 +184,7 @@ class SitesData:
 
         Parameters
         ----------
-        trajectory : GemdatTrajectory
+        trajectory : Trajectory
             Input trajectory
         diff_coords:
             Input array with (diffusing) atom coordinates [time, atom, (x, y, z)]

--- a/src/sites.py
+++ b/src/sites.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
+import typing
 import warnings
 from collections import Counter, defaultdict
-from types import SimpleNamespace
-from typing import TYPE_CHECKING
 
 import numpy as np
 from MDAnalysis.lib.pkdtree import PeriodicKDTree
@@ -13,8 +12,10 @@ from scipy.constants import Boltzmann, angstrom, elementary_charge
 
 from .utils import bfill, ffill, is_lattice_similar
 
-if TYPE_CHECKING:
-    from gemdat.data import SimulationData
+if typing.TYPE_CHECKING:
+    from types import SimpleNamespace
+
+    from gemdat.trajectory import GemdatTrajectory
 
 NOSITE = -1
 
@@ -45,23 +46,25 @@ class SitesData:
             warnings.warn(f'Lattice mismatch: {this_lattice.parameters} '
                           f'vs. {other_lattice.parameters}')
 
-    def calculate_all(self, data: SimulationData, extras: SimpleNamespace,
-                      **kwargs):
+    def calculate_all(self, trajectory: GemdatTrajectory,
+                      extras: SimpleNamespace, **kwargs):
         """Calculate all parameters.
 
         Parameters
         ----------
-        data : SimulationData
-            Input simulation data
+        trajectory : GemdatTrajectory
+            Input trajectory
         extras : SimpleNamespace
             Extra parameters
         """
-        self.warn_if_lattice_not_similar(data.structure.lattice)
+        lattice = trajectory.get_lattice()
+
+        self.warn_if_lattice_not_similar(lattice)
 
         self.dist_close = self.calculate_dist_close(
-            data, vibration_amplitude=extras.vibration_amplitude)
+            trajectory, vibration_amplitude=extras.vibration_amplitude)
         self.atom_sites = self.calculate_atom_sites(
-            data, diff_coords=extras.diff_coords)
+            trajectory, diff_coords=extras.diff_coords)
         self.atom_sites_to, self.atom_sites_from = self.calculate_atom_sites_transitions(
         )
 
@@ -81,16 +84,16 @@ class SitesData:
         self.n_jumps = len(self.all_transitions)
 
         self.jump_diffusivity = self.calculate_jump_diffusivity(
-            lattice=data.lattice,
+            lattice=lattice,
             n_diffusing=extras.n_diffusing,
             total_time=extras.total_time,
             dimensions=extras.diffusion_dimensions)
         self.correlation_factor = extras.tracer_diff / self.jump_diffusivity
 
         self.collective, self.coll_jumps, self.n_solo_jumps = self.calculate_collective(
-            lattice=data.lattice,
+            lattice=lattice,
             attempt_freq=extras.attempt_freq,
-            time_step=data.time_step,
+            time_step=trajectory.time_step,
             **kwargs)
 
         self.solo_frac = self.n_solo_jumps / len(self.all_transitions)
@@ -110,7 +113,7 @@ class SitesData:
                 total_time=extras.total_time,
                 n_diffusing=extras.n_diffusing,
                 attempt_freq=extras.attempt_freq,
-                temperature=data.temperature)
+                temperature=trajectory.temperature)
 
     @property
     def jump_names(self) -> list[str]:
@@ -120,15 +123,15 @@ class SitesData:
         """
         return ['->'.join(key) for key in self.jumps]
 
-    def calculate_dist_close(self, data: SimulationData,
+    def calculate_dist_close(self, trajectory: GemdatTrajectory,
                              vibration_amplitude: float):
         """Calculate tolerance wihin which atoms are considered to be close to
         a site.
 
         Parameters
         ----------
-        data : SimulationData
-            Simulation data
+        trajectory : GemdatTrajectory
+            Input trajectory
         vibration_amplitude : float
             Vibration amplitude
 
@@ -137,10 +140,10 @@ class SitesData:
         dist_close : float
             Atoms within this distance (in Angstrom) are considered to be close to a site
         """
+        lattice = trajectory.get_lattice()
         dist_close = 2 * vibration_amplitude
 
-        pdist = data.lattice.get_all_distances(self.site_coords,
-                                               self.site_coords)
+        pdist = lattice.get_all_distances(self.site_coords, self.site_coords)
         min_dist = np.min(pdist[np.triu_indices_from(pdist, k=1)])
 
         if min_dist < 2 * dist_close:
@@ -171,7 +174,7 @@ class SitesData:
 
         return dist_close
 
-    def calculate_atom_sites(self, data: SimulationData,
+    def calculate_atom_sites(self, trajectory: GemdatTrajectory,
                              diff_coords: np.ndarray) -> np.ndarray:
         """Calculate nearest site for each atom coordinate.
 
@@ -181,8 +184,8 @@ class SitesData:
 
         Parameters
         ----------
-        data : SimulationData
-            Simulation data
+        trajectory : GemdatTrajectory
+            Input trajectory
         diff_coords:
             Input array with (diffusing) atom coordinates [time, atom, (x, y, z)]
 
@@ -196,7 +199,7 @@ class SitesData:
         coords = diff_coords
 
         # Unit cell parameters
-        lattice = data.lattice
+        lattice = trajectory.get_lattice()
 
         # Atoms within this distance (in Angstrom) are considered to be close to a site
         dist_close = self.dist_close

--- a/src/trajectory.py
+++ b/src/trajectory.py
@@ -1,0 +1,82 @@
+import pickle
+from pathlib import Path
+from typing import Optional
+
+from pymatgen.core.trajectory import Trajectory
+from pymatgen.io import vasp
+
+
+class GemdatTrajectory(Trajectory):
+
+    @classmethod
+    def from_cache(cls, cache: str | Path):
+        """Load data from cache using pickle.
+
+        Parameters
+        ----------
+        cache : Path
+            Name of cache file
+        """
+        with open(cache, 'rb') as f:
+            obj = pickle.load(f)
+        return obj
+
+    def to_cache(self, cache: str | Path):
+        """Dump data to cache using pickle.
+
+        Parameters
+        ----------
+        cache : Path
+            Name of cache file
+        """
+        with open(cache, 'wb') as f:
+            pickle.dump(self, f)
+
+    @classmethod
+    def from_vasprun(cls,
+                     xml_file: str | Path,
+                     cache: Optional[str | Path] = None):
+        """Load data from vasprun.xml.
+
+        Parameters
+        ----------
+        xml_file : Path
+            Path to vasprun.xml
+        cache : Optional[Path], optional
+            Path to cache data for vasprun.xml
+
+        Returns
+        -------
+        data : Data
+            Dataclass with simulation data
+        """
+        if not cache:
+            cache = Path(str(xml_file) + '.cache')
+
+        if Path(cache).exists():
+            try:
+                return cls.from_cache(cache)
+            except Exception as e:
+                print(e)
+                print('Error reading from cache, reading full VaspRun')
+
+        run = vasp.Vasprun(
+            xml_file,
+            parse_dos=False,
+            parse_eigen=False,
+            parse_projected_eigen=False,
+            parse_potcar_file=False,
+        )
+
+        obj = cls.from_structures(
+            run.structures,
+            constant_lattice=False,
+            time_step=run.parameters['POTIM'] * 1e-15,
+        )
+        obj.to_positions()
+        obj.temperature = run.parameters['TEBEG']
+
+        if cache:
+            obj.to_cache(cache)
+
+        return obj

--- a/src/trajectory.py
+++ b/src/trajectory.py
@@ -103,6 +103,7 @@ class GemdatTrajectory(Trajectory):
 
     def __getitem__(self, frames):
         new = super().__getitem__(frames)
-        new.__class__ = self.__class__
-        new.temperature = self.temperature
+        if isinstance(new, Trajectory):
+            new.__class__ = self.__class__
+            new.temperature = self.temperature
         return new

--- a/src/trajectory.py
+++ b/src/trajectory.py
@@ -2,6 +2,7 @@ import pickle
 from pathlib import Path
 from typing import Optional
 
+from pymatgen.core import Lattice
 from pymatgen.core.trajectory import Trajectory
 from pymatgen.io import vasp
 
@@ -70,7 +71,7 @@ class GemdatTrajectory(Trajectory):
 
         obj = cls.from_structures(
             run.structures,
-            constant_lattice=False,
+            constant_lattice=True,
             time_step=run.parameters['POTIM'] * 1e-15,
         )
         obj.to_positions()
@@ -80,3 +81,28 @@ class GemdatTrajectory(Trajectory):
             obj.to_cache(cache)
 
         return obj
+
+    def get_lattice(self, idx: int | None = None) -> Lattice:
+        """Get lattice.
+
+        Parameters
+        ----------
+        idx : int | None, optional
+            Optionally, get lattice at specified index if the lattice is not constant
+
+        Returns
+        -------
+        lattice : Lattice
+            Pymatgen Lattice object
+        """
+        if self.constant_lattice:
+            return Lattice(self.lattice)
+
+        latt = self.lattices[idx]
+        return Lattice(latt)
+
+    def __getitem__(self, frames):
+        new = super().__getitem__(frames)
+        new.__class__ = self.__class__
+        new.temperature = self.temperature
+        return new

--- a/src/trajectory.py
+++ b/src/trajectory.py
@@ -3,11 +3,11 @@ from pathlib import Path
 from typing import Optional
 
 from pymatgen.core import Lattice
-from pymatgen.core.trajectory import Trajectory
+from pymatgen.core.trajectory import Trajectory as PymatgenTrajectory
 from pymatgen.io import vasp
 
 
-class GemdatTrajectory(Trajectory):
+class Trajectory(PymatgenTrajectory):
 
     @classmethod
     def from_cache(cls, cache: str | Path):
@@ -102,8 +102,9 @@ class GemdatTrajectory(Trajectory):
         return Lattice(latt)
 
     def __getitem__(self, frames):
+        """Hack around pymatgen Trajectory limitations."""
         new = super().__getitem__(frames)
-        if isinstance(new, Trajectory):
+        if isinstance(new, PymatgenTrajectory):
             new.__class__ = self.__class__
             new.temperature = self.temperature
         return new

--- a/src/volume.py
+++ b/src/volume.py
@@ -6,17 +6,17 @@ import numpy as np
 from pymatgen.io.vasp import VolumetricData
 
 if typing.TYPE_CHECKING:
-    from gemdat.trajectory import GemdatTrajectory
+    from gemdat.trajectory import Trajectory
 
 
-def trajectory_to_volume(trajectory: GemdatTrajectory,
+def trajectory_to_volume(trajectory: Trajectory,
                          resolution: float = 0.2,
                          cartesian: bool = False) -> np.ndarray:
     """Calculate density volume from list of coordinates.
 
     Parameters
     ----------
-    trajectory : GemdatTrajectory
+    trajectory : Trajectory
         Input trajectory
     resolution : float, optional
         Minimum resolution for the voxels in Angstrom
@@ -68,14 +68,14 @@ def trajectory_to_volume(trajectory: GemdatTrajectory,
     return vol
 
 
-def trajectory_to_vasp_volume(trajectory: GemdatTrajectory,
+def trajectory_to_vasp_volume(trajectory: Trajectory,
                               resolution: float = 0.2,
                               filename: str | None = None) -> VolumetricData:
     """Calculate density volume as from list of coordinates.
 
     Parameters
     ----------
-    trajectory : GemdatTrajectory
+    trajectory : Trajectory
         Input trajectory
     resolution : float, optional
         Minimum resolution for the voxels in Angstrom

--- a/src/volume.py
+++ b/src/volume.py
@@ -6,18 +6,21 @@ import numpy as np
 from pymatgen.io.vasp import VolumetricData
 
 if typing.TYPE_CHECKING:
-    from gemdat.trajectory import Trajectory
+    from pymatgen.core import Lattice, Structure
 
 
-def trajectory_to_volume(trajectory: Trajectory,
+def trajectory_to_volume(coords: np.ndarray,
+                         lattice: Lattice,
                          resolution: float = 0.2,
                          cartesian: bool = False) -> np.ndarray:
     """Calculate density volume from list of coordinates.
 
     Parameters
     ----------
-    trajectory : Trajectory
-        Input trajectory
+    coords : np.ndarray
+        Trajectory coordinates
+    lattice : Lattice
+        Lattice coordinates
     resolution : float, optional
         Minimum resolution for the voxels in Angstrom
     cartesian : bool, optional
@@ -29,8 +32,7 @@ def trajectory_to_volume(trajectory: Trajectory,
     vol : np.ndarray
         3D numpy volume array
     """
-    lattice = trajectory.get_lattice()
-    coords = trajectory.coords.reshape(-1, 3)
+    coords = coords.reshape(-1, 3)
 
     if cartesian:
         coords = lattice.get_cartesian_coords(coords)
@@ -68,15 +70,18 @@ def trajectory_to_volume(trajectory: Trajectory,
     return vol
 
 
-def trajectory_to_vasp_volume(trajectory: Trajectory,
+def trajectory_to_vasp_volume(coords: np.ndarray,
+                              structure: Structure,
                               resolution: float = 0.2,
                               filename: str | None = None) -> VolumetricData:
     """Calculate density volume as from list of coordinates.
 
     Parameters
     ----------
-    trajectory : Trajectory
-        Input trajectory
+    coords : np.ndarray
+        Trajectory coordinates
+    structure : Structure
+        Input structure
     resolution : float, optional
         Minimum resolution for the voxels in Angstrom
     filename : str | None, optional
@@ -87,10 +92,11 @@ def trajectory_to_vasp_volume(trajectory: Trajectory,
     vol : VolumetricData
         Output volumetric data object
     """
-    vol = trajectory_to_volume(trajectory=trajectory, resolution=resolution)
+    vol = trajectory_to_volume(coords=coords,
+                               lattice=structure.lattice,
+                               resolution=resolution)
 
-    vasp_vol = VolumetricData(structure=trajectory.get_structure(0),
-                              data={'total': vol})
+    vasp_vol = VolumetricData(structure=structure, data={'total': vol})
 
     if filename:
         vasp_vol.write_file(filename)

--- a/tests/displacement_test.py
+++ b/tests/displacement_test.py
@@ -2,10 +2,10 @@ from types import SimpleNamespace
 
 import numpy as np
 from gemdat.calculate import Displacements
-from gemdat.trajectory import GemdatTrajectory
+from gemdat.trajectory import Trajectory
 from pymatgen.core import Species
 
-trajectory = GemdatTrajectory(
+trajectory = Trajectory(
     coords=np.array([
         [[0.5, .45, .9]],
         [[0, .9, .2]],

--- a/tests/displacement_test.py
+++ b/tests/displacement_test.py
@@ -1,37 +1,39 @@
 from types import SimpleNamespace
 
 import numpy as np
-from gemdat import SimulationData
 from gemdat.calculate import Displacements
-from pymatgen.core import Lattice, Species
+from gemdat.trajectory import GemdatTrajectory
+from pymatgen.core import Species
 
-data = SimulationData(
-    trajectory_coords=np.array([[[0, 0, .1]], [[0.5, .45, .9]], [[0, .9, .2]],
-                                [[0.5, .42, .8]], [[0, .1, .25]],
-                                [[0.5, .59, 0]]]),
-    lattice=Lattice(matrix=np.eye(3)),
+trajectory = GemdatTrajectory(
+    coords=np.array([
+        [[0.5, .45, .9]],
+        [[0, .9, .2]],
+        [[0.5, .42, .8]],
+        [[0, .1, .25]],
+        [[0.5, .59, 0]],
+    ]),
+    lattice=np.eye(3),
     species=[Species('Li')],
-    time_step=None,
-    temperature=None,
-    parameters=None,
-    structure=None,
 )
-extras = SimpleNamespace(
-    equilibration_steps=1,
-    diffusing_element='Li',
-)
+extras = SimpleNamespace(diffusing_element='Li', )
 
 
 def test_displacement_calculate_all():
-    ret = Displacements.calculate_all(data, extras)
-    assert (np.array_equal(
+    ret = Displacements.calculate_all(trajectory, extras)
+    assert np.array_equal(
         ret['cell_offsets'],
-        np.array([[[0, 0, 0]], [[-1, 0, -1]], [[0, 0, 0]], [[-1, 0, -1]],
-                  [[0, 0, 0]], [[-1, 0, 0]]])))
-    assert (np.allclose(
+        np.array([
+            [[0, 0, 0]],
+            [[1, 0, 1]],
+            [[0, 0, 0]],
+            [[1, 0, 1]],
+            [[0, 0, 1]],
+        ]))
+    assert np.allclose(
         ret['displacements'],
-        np.array([[0., 0.73654599, 0.10440307, 0.70356236, 0.17204651]])))
+        np.array([[0., 0.73654599, 0.10440307, 0.70356236, 0.17204651]]))
 
-    assert (np.allclose(
+    assert np.allclose(
         ret['diff_displacements'],
-        np.array([[0., 0.73654599, 0.10440307, 0.70356236, 0.17204651]])))
+        np.array([[0., 0.73654599, 0.10440307, 0.70356236, 0.17204651]]))

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -35,10 +35,10 @@ def gemdat_results():
     z_ion = 1
 
     trajectory = Trajectory.from_vasprun(VASP_XML)
+    trajectory = trajectory[equilibration_steps:]
 
     extras = calculate_all(
         trajectory,
-        equilibration_steps=equilibration_steps,
         diffusing_element=diffusing_element,
         z_ion=z_ion,
         diffusion_dimensions=diffusion_dimensions,
@@ -56,10 +56,10 @@ def gemdat_results_subset():
     z_ion = 1
 
     trajectory = Trajectory.from_vasprun(VASP_XML)
+    trajectory = trajectory[equilibration_steps:]
 
     extras = calculate_all(
         trajectory,
-        equilibration_steps=equilibration_steps,
         diffusing_element=diffusing_element,
         z_ion=z_ion,
         diffusion_dimensions=diffusion_dimensions,

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -13,7 +13,7 @@ from gemdat import SitesData
 from gemdat.data import calculate_all
 from gemdat.io import load_known_material
 from gemdat.rdf import calculate_rdfs
-from gemdat.trajectory import GemdatTrajectory
+from gemdat.trajectory import Trajectory
 from gemdat.volume import trajectory_to_volume
 
 DATA_DIR = Path(__file__).parent / 'data'
@@ -34,7 +34,7 @@ def gemdat_results():
     diffusion_dimensions = 3
     z_ion = 1
 
-    trajectory = GemdatTrajectory.from_vasprun(VASP_XML)
+    trajectory = Trajectory.from_vasprun(VASP_XML)
 
     extras = calculate_all(
         trajectory,
@@ -55,7 +55,7 @@ def gemdat_results_subset():
     diffusion_dimensions = 3
     z_ion = 1
 
-    trajectory = GemdatTrajectory.from_vasprun(VASP_XML)
+    trajectory = Trajectory.from_vasprun(VASP_XML)
 
     extras = calculate_all(
         trajectory,

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -9,9 +9,11 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-from gemdat import SimulationData, SitesData
+from gemdat import SitesData
+from gemdat.data import calculate_all
 from gemdat.io import load_known_material
 from gemdat.rdf import calculate_rdfs
+from gemdat.trajectory import GemdatTrajectory
 from gemdat.volume import trajectory_to_volume
 
 DATA_DIR = Path(__file__).parent / 'data'
@@ -32,16 +34,17 @@ def gemdat_results():
     diffusion_dimensions = 3
     z_ion = 1
 
-    data = SimulationData.from_vasprun(VASP_XML)
+    trajectory = GemdatTrajectory.from_vasprun(VASP_XML)
 
-    extras = data.calculate_all(
+    extras = calculate_all(
+        trajectory,
         equilibration_steps=equilibration_steps,
         diffusing_element=diffusing_element,
         z_ion=z_ion,
         diffusion_dimensions=diffusion_dimensions,
     )
 
-    return (data, extras)
+    return (trajectory, extras)
 
 
 @pytest.fixture
@@ -52,9 +55,10 @@ def gemdat_results_subset():
     diffusion_dimensions = 3
     z_ion = 1
 
-    data = SimulationData.from_vasprun(VASP_XML)
+    trajectory = GemdatTrajectory.from_vasprun(VASP_XML)
 
-    extras = data.calculate_all(
+    extras = calculate_all(
+        trajectory,
         equilibration_steps=equilibration_steps,
         diffusing_element=diffusing_element,
         z_ion=z_ion,
@@ -62,7 +66,7 @@ def gemdat_results_subset():
         n_parts=1,
     )
 
-    return (data, extras)
+    return (trajectory, extras)
 
 
 @pytest.fixture
@@ -72,9 +76,9 @@ def structure():
 
 @vaspxml_available
 def test_volume(gemdat_results):
-    data, extras = gemdat_results
+    trajectory, extras = gemdat_results
 
-    vol = trajectory_to_volume(lattice=data.lattice,
+    vol = trajectory_to_volume(lattice=trajectory.get_lattice(),
                                coords=extras.diff_coords,
                                resolution=0.2)
 
@@ -85,9 +89,9 @@ def test_volume(gemdat_results):
 
 @vaspxml_available
 def test_volume_cartesian(gemdat_results):
-    data, extras = gemdat_results
+    trajectory, extras = gemdat_results
 
-    vol = trajectory_to_volume(lattice=data.lattice,
+    vol = trajectory_to_volume(lattice=trajectory.get_lattice(),
                                coords=extras.diff_coords,
                                resolution=0.2,
                                cartesian=True)
@@ -109,10 +113,10 @@ def test_tracer(gemdat_results):
 
 @vaspxml_available
 def test_sites(gemdat_results, structure):
-    data, extras = gemdat_results
+    trajectory, extras = gemdat_results
 
     sites = SitesData(structure)
-    sites.calculate_all(data=data, extras=extras)
+    sites.calculate_all(trajectory=trajectory, extras=extras)
 
     n_steps = extras.n_steps
     n_diffusing = extras.n_diffusing
@@ -205,24 +209,23 @@ def test_sites(gemdat_results, structure):
 
 @vaspxml_available
 def test_rdf(gemdat_results_subset, structure):
-    data, extras = gemdat_results_subset
+    trajectory, extras = gemdat_results_subset
 
     structure = load_known_material('argyrodite')
 
     sites = SitesData(structure)
-    sites.calculate_all(data=data, extras=extras)
+    sites.calculate_all(trajectory=trajectory, extras=extras)
 
     rdfs = calculate_rdfs(
-        data=data,
+        trajectory=trajectory,
         sites=sites,
         diff_coords=extras.diff_coords,
         n_steps=extras.n_steps,
-        equilibration_steps=extras.equilibration_steps,
         max_dist=5,
     )
 
     expected_states = {'~>48h', '@48h', '48h->48h'}
-    expected_symbols = set(data.structure.symbol_set)
+    expected_symbols = set(trajectory.get_structure(0).symbol_set)
 
     assert isinstance(rdfs, dict)
 

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 from gemdat import SitesData
-from gemdat.data import calculate_all
+from gemdat.calculate import calculate_all
 from gemdat.io import load_known_material
 from gemdat.rdf import calculate_rdfs
 from gemdat.trajectory import Trajectory

--- a/tests/tracer_test.py
+++ b/tests/tracer_test.py
@@ -1,19 +1,16 @@
 from types import SimpleNamespace
 
 import numpy as np
-from gemdat import SimulationData
 from gemdat.calculate.tracer import Tracer
-from pymatgen.core import Lattice
+from gemdat.trajectory import GemdatTrajectory
 
-data = SimulationData(
+trajectory = GemdatTrajectory(
+    coords=[[0, 0, 0], [0, 0, 0]],
+    species=['Li'],
     time_step=1,
-    trajectory_coords=None,
-    lattice=Lattice(matrix=np.eye(3) * 10e10),
-    species=None,
-    temperature=1,
-    parameters=None,
-    structure=None,
+    lattice=np.eye(3) * 10e10,
 )
+trajectory.temperature = 1
 extras = SimpleNamespace(
     diff_displacements=np.array(
         [[0., 0.73654599, 0.10440307, 0.70356236, 0.17204651]]),
@@ -25,7 +22,7 @@ extras = SimpleNamespace(
 
 
 def test_vibration_calculate_all():
-    ret = Tracer.calculate_all(data, extras)
+    ret = Tracer.calculate_all(trajectory, extras)
     assert (np.isclose(ret['particle_density'], 0.001))
     assert (np.isclose(ret['mol_per_liter'], 1.6605390671738466e-30))
     assert (np.isclose(ret['tracer_diff'], 4.933333600530017e-23))

--- a/tests/tracer_test.py
+++ b/tests/tracer_test.py
@@ -2,9 +2,9 @@ from types import SimpleNamespace
 
 import numpy as np
 from gemdat.calculate.tracer import Tracer
-from gemdat.trajectory import GemdatTrajectory
+from gemdat.trajectory import Trajectory
 
-trajectory = GemdatTrajectory(
+trajectory = Trajectory(
     coords=[[0, 0, 0], [0, 0, 0]],
     species=['Li'],
     time_step=1,

--- a/tests/vibration_test.py
+++ b/tests/vibration_test.py
@@ -1,25 +1,16 @@
 from types import SimpleNamespace
 
 import numpy as np
-from gemdat import SimulationData
 from gemdat.calculate import Vibration
 from gemdat.calculate.vibration import meanfreq
 
-data = SimulationData(
-    time_step=1,
-    trajectory_coords=None,
-    lattice=None,
-    species=None,
-    temperature=None,
-    parameters=None,
-    structure=None,
-)
+mock_trajectory = SimpleNamespace(time_step=1)
 extras = SimpleNamespace(diff_displacements=np.array(
     [[0., 0.73654599, 0.10440307, 0.70356236, 0.17204651]]), )
 
 
 def test_vibration_calculate_all():
-    ret = Vibration.calculate_all(data, extras)
+    ret = Vibration.calculate_all(mock_trajectory, extras)
     assert (np.allclose(
         ret['speed'],
         np.array([[0., 0.73654599, -0.63214292, 0.59915929, -0.53151585]])))


### PR DESCRIPTION
In this PR I'm exploring `pymatgen.core.trajectory.Trajectory` to see if we can use that instead of `SimulationData`. It seems that everything we need is more or less available from this object alone. 

The goal is to replace `SimulationData` as the data structure, and use `Trajectory` instead. To start, I am making this a subclass to see what we need to do to get this to work.

One of the challenges will be to structure the data in such a way that we can drag along all the `extras`.

Addresses part of #67

Also helps with #62

### Todo

- [x] ~Remove `data.py`~ -> Stores `calculate_all()` function that we still need
- [x] Update tests for `GemdatTrajectory`
- [x] Remove tests for `SimulationData` (do we have any?)
- [x] Update dashboard
- [x] Update plots
- [x] Rename `GemdatTrajectory` -> `Trajectory`, `Trajectory` -> `PymatgenTrajectory`
- [x] Fix rdf calculation / plots, these look off
- [x] Confirm that all plots are the same
- [x] `trajectory_to_volume` takes `Trajectory`, but actually needs `diff_coords`

### Future

- [ ] Add some sort of `Trajectory.metadata` attribute to track some sort of global simulation parameters like temperature
- [ ] Replace test trajectories by fixtures
- [ ] What makes sense to move from `calculate_all()` to `GemdatTrajectory`?
- [ ] Add intuitive method to `Trajectory` to easily get coordinates for diffusing atom