### PR TITLE
Add filter method to Trajectory

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,21 +27,37 @@ Suggestions, improvements, and edits are most welcome.
 
 ## Usage
 
-The following snippet can be used to test the code (provided that you have some VASP data or intermediate `.mat` files.
+The following snippet can be used to test the code using VASP data.
 
 ```python
-from gemdat import SimulationData, plot_all, plot
+from gemdat import Trajectory, plot_all, plot
+from gemdat.calculate.extras import calculate_all
 
-data = SimulationData.from_vasprun(Path('../example/vasprun.xml'), cache=Path('cache'))
-extra = data.calculate_all(equilibration_steps=1250, diffusing_element='Li')
+trajectory = Trajectory.from_vasprun(Path('../example/vasprun.xml'))
+extras = calculate_all(diffusing_element='Li')
 
-plot_all(data = data, **extra)
+structure = load_known_material('argyrodite', supercell=(2, 1, 1))
+
+sites = SitesData(structure)
+sites.calculate_all(trajectory=trajectory,
+                    extras=extras)
+
+plot_all(trajectory=trajectory,
+         sites=sites,
+         **vars(extras),
 ```
 
-**not yet available:**
+Or, one function to do everything:
+
 ```python
-import gemdat
-gemdat.analyse_md('<path to data>', 'Li', 'argyrodite')
+from gemdat.legacy import analyse_md
+
+trajectory, sites, extras = analyse_md(
+   '/data/vasprun.xml',
+   diff_elem='Li',
+   supercell=(2, 1, 1),
+   material='argyrodite',
+)
 ```
 
 ## Development

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,7 @@
 from .io import load_cif, load_known_material
 from .plot import plot, plot_all
 from .sites import SitesData
+from .trajectory import Trajectory
 
 __version__ = '0.0.1'
 __all__ = [
@@ -9,4 +10,5 @@ __all__ = [
     'plot',
     'plot_all',
     'SitesData',
+    'Trajectory',
 ]

--- a/src/calculate/extras.py
+++ b/src/calculate/extras.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import typing
 from types import SimpleNamespace
 
-import numpy as np
-
 from .displacements import Displacements
 from .tracer import Tracer
 from .vibration import Vibration
@@ -65,9 +63,3 @@ def _add_shared_variables(trajectory: Trajectory, extras: SimpleNamespace):
     extras.n_steps = len(trajectory)
 
     extras.total_time = extras.n_steps * trajectory.time_step
-
-    diffusing_idx = np.argwhere([
-        e.name == extras.diffusing_element for e in trajectory.species
-    ]).flatten()
-
-    extras.diff_coords = trajectory.coords[:, diffusing_idx, :]

--- a/src/calculate/tracer.py
+++ b/src/calculate/tracer.py
@@ -50,7 +50,7 @@ class Tracer:
         # Do they mean the total displacement (i.e. last column)?
         msd = np.mean(extras.diff_displacements[:, -1]**2)  # Angstrom^2
 
-        temperature = trajectory.temperature
+        temperature = trajectory.metadata['temperature']
 
         # Diffusivity = MSD/(2*dimensions*time)
         tracer_diff = (msd * angstrom**2) / (2 * extras.diffusion_dimensions *

--- a/src/dashboard/run.py
+++ b/src/dashboard/run.py
@@ -80,27 +80,27 @@ number_of_cols = 3  # Number of figure columns
 
 with st.spinner('Processing trajectory...'):
     trajectory = trajectory[equilibration_steps:]
-    extra = calculate_all(trajectory, diffusing_element=diffusing_element)
+    extras = calculate_all(trajectory, diffusing_element=diffusing_element)
 
 col1, col2, col3 = st.columns(3)
 
 with col1:
     import uncertainties as u
-    attempt_freq = u.ufloat(extra.attempt_freq, extra.attempt_freq_std)
+    attempt_freq = u.ufloat(extras.attempt_freq, extras.attempt_freq_std)
     st.metric('Attempt frequency ($\\mathrm{s^{-1}}$)',
               value=f'{attempt_freq:g}')
     st.metric('Vibration amplitude ($\\mathrm{Å}$)',
-              value=f'{extra.vibration_amplitude:g}')
+              value=f'{extras.vibration_amplitude:g}')
 with col2:
     st.metric('Particle density ($\\mathrm{m^{-3}}$)',
-              value=f'{extra.particle_density:g}')
+              value=f'{extras.particle_density:g}')
     st.metric('Mol per liter ($\\mathrm{mol/l}$)',
-              value=f'{extra.mol_per_liter:g}')
+              value=f'{extras.mol_per_liter:g}')
 with col3:
     st.metric('Tracer diffusivity ($\\mathrm{m^2/s}$)',
-              value=f'{extra.tracer_diff:g}')
+              value=f'{extras.tracer_diff:g}')
     st.metric('Tracer conductivity ($\\mathrm{S/m}$)',
-              value=f'{extra.tracer_conduc:g}')
+              value=f'{extras.tracer_conduc:g}')
 
 tab1, tab2 = st.tabs(['Default plots', 'RDF plots'])
 
@@ -119,11 +119,11 @@ with tab1:
 
     with st.spinner('Calculating jumps...'):
         sites = SitesData(sites_structure)
-        sites.calculate_all(trajectory=trajectory, extras=extra)
+        sites.calculate_all(trajectory=trajectory, extras=extras)
 
     figures = plot_all(trajectory=trajectory,
                        sites=sites,
-                       **vars(extra),
+                       **vars(extras),
                        show=False)
 
     # automagically divide the plots over the number of columns
@@ -149,8 +149,7 @@ with tab2:
             rdfs = calculate_rdfs(
                 trajectory=trajectory,
                 sites=sites,
-                diff_coords=extra.diff_coords,
-                n_steps=extra.n_steps,
+                species=extras.diffusing_element,
                 max_dist=max_dist_rdf,
                 resolution=resolution_rdf,
             )

--- a/src/legacy.py
+++ b/src/legacy.py
@@ -109,7 +109,7 @@ def analyse_md(
     filename = 'volume.vasp'
     print(f'Writing trajectory as a volume to `{filename}')
 
-    trajectory_to_vasp_volume(coords=extras.diff_coords,
+    trajectory_to_vasp_volume(trajectory=trajectory.filter(diff_elem),
                               structure=trajectory.get_structure(0),
                               resolution=density_resolution,
                               filename=filename)
@@ -118,8 +118,7 @@ def analyse_md(
         rdf_data = calculate_rdfs(
             trajectory=trajectory,
             sites=sites,
-            diff_coords=extras.diff_coords,
-            n_steps=extras.n_steps,
+            species=diff_elem,
             max_dist=rdf_max_dist,
             resolution=rdf_res,
         )

--- a/src/sites.py
+++ b/src/sites.py
@@ -114,7 +114,7 @@ class SitesData:
                 total_time=extras.total_time,
                 n_diffusing=extras.n_diffusing,
                 attempt_freq=extras.attempt_freq,
-                temperature=trajectory.temperature)
+                temperature=trajectory.metadata['temperature'])
 
     @property
     def jump_names(self) -> list[str]:

--- a/src/trajectory.py
+++ b/src/trajectory.py
@@ -10,6 +10,10 @@ from pymatgen.io import vasp
 
 class Trajectory(PymatgenTrajectory):
 
+    def __init__(self, *, metadata: dict | None = None, **kwargs):
+        super().__init__(**kwargs)
+        self.metadata = metadata if metadata else None
+
     @classmethod
     def from_cache(cls, cache: str | Path):
         """Load data from cache using pickle.
@@ -70,13 +74,15 @@ class Trajectory(PymatgenTrajectory):
             parse_potcar_file=False,
         )
 
+        metadata = {'temperature': run.parameters['TEBEG']}
+
         obj = cls.from_structures(
             run.structures,
             constant_lattice=True,
             time_step=run.parameters['POTIM'] * 1e-15,
+            metadata=metadata,
         )
         obj.to_positions()
-        obj.temperature = run.parameters['TEBEG']
 
         if cache:
             obj.to_cache(cache)
@@ -107,7 +113,7 @@ class Trajectory(PymatgenTrajectory):
         new = super().__getitem__(frames)
         if isinstance(new, PymatgenTrajectory):
             new.__class__ = self.__class__
-            new.temperature = self.temperature
+            new.metadata = self.metadata
         return new
 
     def filter(self, species: str | Sequence[str]):

--- a/src/trajectory.py
+++ b/src/trajectory.py
@@ -1,6 +1,7 @@
 import pickle
+from itertools import compress
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Sequence
 
 from pymatgen.core import Lattice
 from pymatgen.core.trajectory import Trajectory as PymatgenTrajectory
@@ -108,3 +109,24 @@ class Trajectory(PymatgenTrajectory):
             new.__class__ = self.__class__
             new.temperature = self.temperature
         return new
+
+    def filter(self, species: str | Sequence[str]):
+        """Return trajectory with coordinates for specified species only.
+
+        Parameters
+        ----------
+        speces : str | Sequence[str]
+            Species to select, i.e. 'Li'
+
+        Returns
+        -------
+        trajectory : Trajectory
+            Output trajectory with coordinates for selected species only
+        """
+        idx = [sp.name in species for sp in self.species]
+        new_coords = self.coords[:, idx]
+        new_species = list(compress(self.species, idx))
+
+        return self.__class__(species=new_species,
+                              coords=new_coords,
+                              lattice=self.get_lattice())

--- a/src/trajectory.py
+++ b/src/trajectory.py
@@ -117,7 +117,7 @@ class Trajectory(PymatgenTrajectory):
         return new
 
     def filter(self, species: str | Sequence[str]):
-        """Return trajectory with coordinates for specified species only.
+        """Return trajectory with coordinates for given species only.
 
         Parameters
         ----------

--- a/src/volume.py
+++ b/src/volume.py
@@ -81,10 +81,10 @@ def trajectory_to_vasp_volume(trajectory: Trajectory,
     trajectory : np.ndarray
         Input trajectory
     structure : Optional[Structure]
-        Input structure, defaults to trajectory structure. Useful
-        if you want to output the density for a select number of species,
-        and show the host material. Defaults to first structure in
-        trajectory (base coordinates).
+        structure to include in the vasp file, defaults to trajectory structure.
+        Useful if you want to output the density for a select number of species,
+        and show the host structure. Defaults to first structure in
+        given trajectory (base coordinates).
     resolution : float, optional
         Minimum resolution for the voxels in Angstrom
     filename : str | None, optional

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+import numpy as np
+import pytest
+from gemdat.trajectory import Trajectory
+from pymatgen.core import Species
+
+
+@pytest.fixture()
+def trajectory():
+    coords = np.array([
+        [[.2, .0, .0], [.0, .0, .5]],
+        [[.4, .0, .0], [.0, .0, .5]],
+        [[.6, .0, .0], [.0, .0, .5]],
+        [[.8, .0, .0], [.0, .0, .5]],
+        [[.1, .0, .0], [.0, .0, .5]],
+    ])
+
+    return Trajectory(species=[Species('B'), Species('C')],
+                      coords=coords,
+                      lattice=np.eye(3),
+                      metadata={'temperature': 123},
+                      time_step=1)

--- a/tests/displacement_test.py
+++ b/tests/displacement_test.py
@@ -2,38 +2,22 @@ from types import SimpleNamespace
 
 import numpy as np
 from gemdat.calculate import Displacements
-from gemdat.trajectory import Trajectory
-from pymatgen.core import Species
-
-trajectory = Trajectory(
-    coords=np.array([
-        [[0.5, .45, .9]],
-        [[0, .9, .2]],
-        [[0.5, .42, .8]],
-        [[0, .1, .25]],
-        [[0.5, .59, 0]],
-    ]),
-    lattice=np.eye(3),
-    species=[Species('Li')],
-)
-extras = SimpleNamespace(diffusing_element='Li', )
 
 
-def test_displacement_calculate_all():
+def test_displacement_calculate_all(trajectory):
+    extras = SimpleNamespace(diffusing_element='B')
+
     ret = Displacements.calculate_all(trajectory, extras)
+
     assert np.array_equal(
         ret['cell_offsets'],
-        np.array([
-            [[0, 0, 0]],
-            [[1, 0, 1]],
-            [[0, 0, 0]],
-            [[1, 0, 1]],
-            [[0, 0, 1]],
-        ]))
-    assert np.allclose(
-        ret['displacements'],
-        np.array([[0., 0.73654599, 0.10440307, 0.70356236, 0.17204651]]))
+        np.array([[[0, 0, 0], [0, 0, 0]], [[0, 0, 0], [0, 0, 0]],
+                  [[0, 0, 0], [0, 0, 0]], [[0, 0, 0], [0, 0, 0]],
+                  [[1, 0, 0], [0, 0, 0]]]))
 
     assert np.allclose(
-        ret['diff_displacements'],
-        np.array([[0., 0.73654599, 0.10440307, 0.70356236, 0.17204651]]))
+        ret['displacements'],
+        np.array([[0., 0.2, 0.4, 0.6, 0.9], [0., 0., 0., 0., 0.]]))
+
+    assert np.allclose(ret['diff_displacements'],
+                       np.array([0., 0.2, 0.4, 0.6, 0.9]))

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -78,27 +78,28 @@ def structure():
 def test_volume(gemdat_results):
     trajectory, extras = gemdat_results
 
-    vol = trajectory_to_volume(lattice=trajectory.get_lattice(),
-                               coords=extras.diff_coords,
-                               resolution=0.2)
+    diff_trajectory = trajectory.filter(extras.diffusing_element)
+
+    vol = trajectory_to_volume(trajectory=diff_trajectory, resolution=0.2)
 
     assert isinstance(vol, np.ndarray)
     assert vol.shape == (101, 51, 51)
-    assert vol.sum() == extras.n_diffusing * extras.n_steps
+    assert vol.sum() == extras.n_diffusing * len(trajectory)
 
 
 @vaspxml_available
 def test_volume_cartesian(gemdat_results):
     trajectory, extras = gemdat_results
 
-    vol = trajectory_to_volume(lattice=trajectory.get_lattice(),
-                               coords=extras.diff_coords,
+    diff_trajectory = trajectory.filter(extras.diffusing_element)
+
+    vol = trajectory_to_volume(trajectory=diff_trajectory,
                                resolution=0.2,
                                cartesian=True)
 
     assert isinstance(vol, np.ndarray)
     assert vol.shape == (101, 51, 52)
-    assert vol.sum() == extras.n_diffusing * extras.n_steps
+    assert vol.sum() == extras.n_diffusing * len(trajectory)
 
 
 @vaspxml_available
@@ -121,8 +122,6 @@ def test_sites(gemdat_results, structure):
     n_steps = extras.n_steps
     n_diffusing = extras.n_diffusing
     n_sites = sites.n_sites
-
-    assert extras.diff_coords.shape == (n_steps, n_diffusing, 3)
 
     assert sites.atom_sites.shape == (n_steps, n_diffusing)
     assert sites.atom_sites.sum() == 6154859
@@ -219,8 +218,7 @@ def test_rdf(gemdat_results_subset, structure):
     rdfs = calculate_rdfs(
         trajectory=trajectory,
         sites=sites,
-        diff_coords=extras.diff_coords,
-        n_steps=extras.n_steps,
+        species=extras.diffusing_element,
         max_dist=5,
     )
 

--- a/tests/tracer_test.py
+++ b/tests/tracer_test.py
@@ -4,13 +4,11 @@ import numpy as np
 from gemdat.calculate.tracer import Tracer
 from gemdat.trajectory import Trajectory
 
-trajectory = Trajectory(
-    coords=[[0, 0, 0], [0, 0, 0]],
-    species=['Li'],
-    time_step=1,
-    lattice=np.eye(3) * 10e10,
-)
-trajectory.temperature = 1
+trajectory = Trajectory(coords=[[0, 0, 0], [0, 0, 0]],
+                        species=['Li'],
+                        time_step=1,
+                        lattice=np.eye(3) * 10e10,
+                        metadata={'temperature': 1})
 extras = SimpleNamespace(
     diff_displacements=np.array(
         [[0., 0.73654599, 0.10440307, 0.70356236, 0.17204651]]),

--- a/tests/tracer_test.py
+++ b/tests/tracer_test.py
@@ -2,26 +2,20 @@ from types import SimpleNamespace
 
 import numpy as np
 from gemdat.calculate.tracer import Tracer
-from gemdat.trajectory import Trajectory
-
-trajectory = Trajectory(coords=[[0, 0, 0], [0, 0, 0]],
-                        species=['Li'],
-                        time_step=1,
-                        lattice=np.eye(3) * 10e10,
-                        metadata={'temperature': 1})
-extras = SimpleNamespace(
-    diff_displacements=np.array(
-        [[0., 0.73654599, 0.10440307, 0.70356236, 0.17204651]]),
-    total_time=1,
-    n_diffusing=1,
-    diffusion_dimensions=3,
-    z_ion=1,
-)
 
 
-def test_vibration_calculate_all():
+def test_vibration_calculate_all(trajectory):
+    extras = SimpleNamespace(
+        diff_displacements=np.array([[0., 0.1, 0.2, 0.3, 0.4]]),
+        total_time=1e-12,
+        n_diffusing=1,
+        diffusion_dimensions=3,
+        z_ion=1,
+    )
+
     ret = Tracer.calculate_all(trajectory, extras)
-    assert (np.isclose(ret['particle_density'], 0.001))
-    assert (np.isclose(ret['mol_per_liter'], 1.6605390671738466e-30))
-    assert (np.isclose(ret['tracer_diff'], 4.933333600530017e-23))
-    assert (np.isclose(ret['tracer_conduc'], 9.172294469819148e-41))
+
+    assert (np.isclose(ret['particle_density'], 1e30))
+    assert (np.isclose(ret['mol_per_liter'], 1660.5390671738464))
+    assert (np.isclose(ret['tracer_diff'], 2.6666666666666673e-10))
+    assert (np.isclose(ret['tracer_conduc'], 4030.8916603094012))

--- a/tests/trajectory_test.py
+++ b/tests/trajectory_test.py
@@ -1,23 +1,6 @@
 import numpy as np
-import pytest
 from gemdat.trajectory import Trajectory
 from pymatgen.core import Lattice, Species
-
-
-@pytest.fixture
-def trajectory():
-    coords = np.array([
-        [[.0, .0, .0], [.0, .0, .5]],
-        [[.2, .0, .0], [.0, .0, .5]],
-        [[.4, .0, .0], [.0, .0, .5]],
-        [[.6, .0, .0], [.0, .0, .5]],
-        [[.8, .0, .0], [.0, .0, .5]],
-    ])
-
-    return Trajectory(species=[Species('B'), Species('C')],
-                      coords=coords,
-                      lattice=np.eye(3),
-                      metadata={'temperature': 123})
 
 
 def test_trajectory(trajectory):
@@ -60,6 +43,7 @@ def test_caching(trajectory, tmpdir):
 
     assert trajectory.species == t2.species
     assert trajectory.metadata == t2.metadata
+    assert trajectory.time_step == t2.time_step
 
     np.testing.assert_array_equal(trajectory.lattice, t2.lattice)
     np.testing.assert_array_equal(trajectory.base_positions, t2.base_positions)

--- a/tests/trajectory_test.py
+++ b/tests/trajectory_test.py
@@ -1,0 +1,66 @@
+import numpy as np
+import pytest
+from gemdat.trajectory import Trajectory
+from pymatgen.core import Lattice, Species
+
+
+@pytest.fixture
+def trajectory():
+    coords = np.array([
+        [[.0, .0, .0], [.0, .0, .5]],
+        [[.2, .0, .0], [.0, .0, .5]],
+        [[.4, .0, .0], [.0, .0, .5]],
+        [[.6, .0, .0], [.0, .0, .5]],
+        [[.8, .0, .0], [.0, .0, .5]],
+    ])
+
+    return Trajectory(species=[Species('B'), Species('C')],
+                      coords=coords,
+                      lattice=np.eye(3),
+                      metadata={'temperature': 123})
+
+
+def test_trajectory(trajectory):
+    assert isinstance(trajectory, Trajectory)
+    assert trajectory.species == [Species('B'), Species('C')]
+    assert trajectory.coords.shape == (5, 2, 3)
+    assert trajectory.metadata == {'temperature': 123}
+
+
+def test_slice(trajectory):
+    sliced = trajectory[2:]
+
+    assert isinstance(sliced, Trajectory)
+    assert sliced.species == trajectory.species
+    assert sliced.coords.shape == (3, 2, 3)
+    assert sliced.metadata == trajectory.metadata
+
+
+def test_filter(trajectory):
+    t = trajectory.filter('C')
+    assert t.species == [Species('C')]
+    assert np.all(t.coords == [.0, .0, .5])
+
+
+def test_get_lattice(trajectory):
+    lattice = trajectory.get_lattice()
+    expected_lattice = Lattice(np.eye(3))
+
+    assert isinstance(lattice, Lattice)
+    assert lattice == expected_lattice
+
+
+def test_caching(trajectory, tmpdir):
+    cachefile = tmpdir / 'trajectory.cache'
+    trajectory.to_cache(cachefile)
+
+    assert cachefile.exists()
+
+    t2 = Trajectory.from_cache(cachefile)
+
+    assert trajectory.species == t2.species
+    assert trajectory.metadata == t2.metadata
+
+    np.testing.assert_array_equal(trajectory.lattice, t2.lattice)
+    np.testing.assert_array_equal(trajectory.base_positions, t2.base_positions)
+    np.testing.assert_array_equal(trajectory.coords, t2.coords)

--- a/tests/vibration_test.py
+++ b/tests/vibration_test.py
@@ -4,22 +4,18 @@ import numpy as np
 from gemdat.calculate import Vibration
 from gemdat.calculate.vibration import meanfreq
 
-mock_trajectory = SimpleNamespace(time_step=1)
-extras = SimpleNamespace(diff_displacements=np.array(
-    [[0., 0.73654599, 0.10440307, 0.70356236, 0.17204651]]), )
 
+def test_vibration_calculate_all(trajectory):
+    extras = SimpleNamespace(diff_displacements=np.array(
+        [[0., 0.1, 0.2, 0.3, 0.4]]), )
 
-def test_vibration_calculate_all():
-    ret = Vibration.calculate_all(mock_trajectory, extras)
-    assert (np.allclose(
-        ret['speed'],
-        np.array([[0., 0.73654599, -0.63214292, 0.59915929, -0.53151585]])))
-    assert (np.isclose(ret['attempt_freq'], 0.38779581521997086))
-    assert (np.isclose(ret['attempt_freq_std'], 0.))
-    assert (np.allclose(
-        ret['amplitudes'],
-        np.array([0.73654599, -0.63214292, 0.59915929, -0.53151585])))
-    assert (np.isclose(ret['vibration_amplitude'], 0.6277351391878859))
+    ret = Vibration.calculate_all(trajectory, extras)
+
+    assert (np.allclose(ret['speed'], np.array([[0., 0.1, 0.1, 0.1, 0.1]])))
+    assert (np.isclose(ret['attempt_freq'], 0.3))
+    assert (np.isclose(ret['attempt_freq_std'], 0.0))
+    assert (np.allclose(ret['amplitudes'], np.array([0.4])))
+    assert (np.isclose(ret['vibration_amplitude'], 0.0))
 
 
 def test_meanfreq_single_timestep():


### PR DESCRIPTION
Adds filter method from #94 to `Trajectory` class.

In addition:
- Revises code using `diff_coords` to use `.filter()` instead
- Adds a metadata attribute to store arbitrary information about the trajectory.
- Adds trajectory tests
- Updates test to re-use shared trajectory fixture

Closes #67