### PR TITLE
Update pymatgen requirement in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 ]
 dependencies = [
   # 'pymatgen >= 2023.7.14',
-  'pymatgen @ git+https://github.com/stefsmeets/pymatgen@label-update',
+  'pymatgen @ git+https://github.com/materialsproject/pymatgen',
   'numpy',
   'rich',
   'scipy',


### PR DESCRIPTION
Point to pymatgen repo instead of an (outdated) branch on my fork