### PR TITLE
Drift correction

### DIFF
--- a/src/calculate/displacements.py
+++ b/src/calculate/displacements.py
@@ -60,7 +60,7 @@ class Displacements:
         offsets : np.ndarray[i, j, k]
             Integer array with unit cell offset vectors.
         """
-        coords = trajectory.coords
+        coords = trajectory.positions
 
         first = coords[0, np.newaxis]
         diff = np.diff(coords, axis=0, prepend=first)

--- a/src/calculate/displacements.py
+++ b/src/calculate/displacements.py
@@ -113,7 +113,7 @@ class Displacements:
 
         offsets = Displacements.cell_offsets(trajectory)
 
-        corrected_coords = trajectory.coords + offsets
+        corrected_coords = trajectory.positions + offsets
 
         displacements = []
 

--- a/src/calculate/displacements.py
+++ b/src/calculate/displacements.py
@@ -131,5 +131,5 @@ class Displacements:
 
     @staticmethod
     def diff_displacements(*, diffusing_element='Li', displacements, species):
-        idx = np.argwhere([e.name == diffusing_element for e in species])
+        idx = np.argwhere([sp.symbol == diffusing_element for sp in species])
         return displacements[idx].squeeze()

--- a/src/calculate/extras.py
+++ b/src/calculate/extras.py
@@ -59,7 +59,7 @@ def calculate_all(trajectory: Trajectory,
 def _add_shared_variables(trajectory: Trajectory, extras: SimpleNamespace):
     """Add common shared variables to extras namespace."""
     extras.n_diffusing = sum(
-        [e.name == extras.diffusing_element for e in trajectory.species])
+        [sp.symbol == extras.diffusing_element for sp in trajectory.species])
     extras.n_steps = len(trajectory)
 
     extras.total_time = extras.n_steps * trajectory.time_step

--- a/src/plots/displacements.py
+++ b/src/plots/displacements.py
@@ -42,14 +42,14 @@ def plot_displacement_per_element(*, displacements: np.ndarray,
     trajectory.get_structure(0)
     species = trajectory.species
 
-    for specie, displacement in zip(species, displacements):
-        grouped[specie.name].append(displacement)
+    for sp, displacement in zip(species, displacements):
+        grouped[sp.symbol].append(displacement)
 
     fig, ax = plt.subplots()
 
-    for specie, displacement in grouped.items():
+    for symbol, displacement in grouped.items():
         mean_disp = np.mean(displacement, axis=0)
-        ax.plot(mean_disp, lw=0.3, label=specie)
+        ax.plot(mean_disp, lw=0.3, label=symbol)
 
     ax.legend()
     ax.set(title='Displacement per element',

--- a/src/rdf.py
+++ b/src/rdf.py
@@ -98,8 +98,8 @@ def calculate_rdfs(
     structure = trajectory.get_structure(0)
     lattice = trajectory.get_lattice()
 
-    coords = trajectory.coords
-    sp_coords = trajectory.filter(species).coords
+    coords = trajectory.positions
+    sp_coords = trajectory.filter(species).positions
 
     states2str = _get_states(sites.structure.labels)
     states_array = _get_states_array(sites, sites.structure.labels)

--- a/src/rdf.py
+++ b/src/rdf.py
@@ -63,7 +63,8 @@ def _get_symbol_indices(structure: Structure) -> dict[str, np.ndarray]:
     symbols = structure.symbol_set
     return {
         symbol:
-        np.argwhere([e.name == symbol for e in structure.species]).flatten()
+        np.argwhere([sp.symbol == symbol
+                     for sp in structure.species]).flatten()
         for symbol in symbols
     }
 

--- a/src/sites.py
+++ b/src/sites.py
@@ -209,7 +209,7 @@ class SitesData:
         atom_sites = []
 
         for atom_index, atom_coords in enumerate(
-                trajectory.coords.swapaxes(0, 1)):
+                trajectory.positions.swapaxes(0, 1)):
 
             # index and distance of nearest site
             atom_cart_coords = np.dot(atom_coords, lattice.matrix)

--- a/src/trajectory.py
+++ b/src/trajectory.py
@@ -160,7 +160,7 @@ class Trajectory(PymatgenTrajectory):
             Output trajectory with coordinates for selected species only
         """
         idx = [sp.name in species for sp in self.species]
-        new_coords = self.coords[:, idx]
+        new_coords = self.positions[:, idx]
         new_species = list(compress(self.species, idx))
 
         return self.__class__(species=new_species,

--- a/src/trajectory.py
+++ b/src/trajectory.py
@@ -3,6 +3,7 @@ from itertools import compress
 from pathlib import Path
 from typing import Optional, Sequence
 
+import numpy as np
 from pymatgen.core import Lattice
 from pymatgen.core.trajectory import Trajectory as PymatgenTrajectory
 from pymatgen.io import vasp
@@ -13,6 +14,35 @@ class Trajectory(PymatgenTrajectory):
     def __init__(self, *, metadata: dict | None = None, **kwargs):
         super().__init__(**kwargs)
         self.metadata = metadata if metadata else None
+
+    @property
+    def positions(self) -> np.ndarray:
+        """Return trajectory positions as fractional coordinates.
+
+        Returns
+        -------
+        positions : np.ndarray
+            Output array with positions
+        """
+        if self.coords_are_displacement:
+            self.to_positions()
+            return self.coords
+        return self.coords
+
+    @property
+    def displacements(self) -> np.ndarray:
+        """Return trajectory displacements as fractional coordinates from base
+        position.
+
+        Returns
+        -------
+        displacements : np.ndarray
+            Output array with displacements
+        """
+        if self.coords_are_displacement:
+            return self.coords
+        self.to_displacements()
+        return self.coords
 
     @classmethod
     def from_cache(cls, cache: str | Path):

--- a/src/trajectory.py
+++ b/src/trajectory.py
@@ -173,7 +173,7 @@ class Trajectory(PymatgenTrajectory):
         if fixed_species:
             displacements = self.filter(species=fixed_species).displacements
         elif floating_species:
-            species: set[str] = {
+            species = {
                 sp.symbol
                 for sp in self.species if sp.symbol not in floating_species
             }

--- a/src/trajectory.py
+++ b/src/trajectory.py
@@ -148,8 +148,9 @@ class Trajectory(PymatgenTrajectory):
 
     def drift(
         self,
-        fixed_species: None | str | Collection[str],
-        floating_species: None | str | Collection[str],
+        *,
+        fixed_species: None | str | Collection[str] = None,
+        floating_species: None | str | Collection[str] = None,
     ):
         """Compute drift by averaging the displacement from the base positions
         per frame.
@@ -186,8 +187,8 @@ class Trajectory(PymatgenTrajectory):
     def apply_drift_correction(
         self,
         *,
-        fixed_species: None | str | Collection[str],
-        floating_species: None | str | Collection[str],
+        fixed_species: None | str | Collection[str] = None,
+        floating_species: None | str | Collection[str] = None,
     ):
         """Apply drift correction to trajectory. For details see `Trajectory.drift`.
 
@@ -211,9 +212,11 @@ class Trajectory(PymatgenTrajectory):
                            floating_species=floating_species)
 
         return self.__class__(species=self.species,
-                              coords=self.positions - drift,
+                              coords=self.displacements - drift,
                               lattice=self.get_lattice(),
-                              metadata=self.metadata)
+                              metadata=self.metadata,
+                              coords_are_displacement=True,
+                              base_positions=self.base_positions)
 
     def filter(self, species: str | Collection[str]):
         """Return trajectory with coordinates for given species only.

--- a/src/volume.py
+++ b/src/volume.py
@@ -32,7 +32,7 @@ def trajectory_to_volume(trajectory: Trajectory,
     """
     lattice = trajectory.get_lattice()
 
-    coords = trajectory.coords.reshape(-1, 3)
+    coords = trajectory.positions.reshape(-1, 3)
 
     if cartesian:
         coords = lattice.get_cartesian_coords(coords)

--- a/tests/trajectory_test.py
+++ b/tests/trajectory_test.py
@@ -45,6 +45,34 @@ def test_caching(trajectory, tmpdir):
     assert trajectory.metadata == t2.metadata
     assert trajectory.time_step == t2.time_step
 
-    np.testing.assert_array_equal(trajectory.lattice, t2.lattice)
-    np.testing.assert_array_equal(trajectory.base_positions, t2.base_positions)
-    np.testing.assert_array_equal(trajectory.coords, t2.coords)
+    np.testing.assert_allclose(trajectory.lattice, t2.lattice)
+    np.testing.assert_allclose(trajectory.base_positions, t2.base_positions)
+    np.testing.assert_allclose(trajectory.coords, t2.coords)
+
+
+def test_displacements_property(trajectory):
+    trajectory.to_positions()
+
+    np.testing.assert_allclose(trajectory.displacements, [
+        [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
+        [[0.2, 0.0, 0.0], [0.0, 0.0, 0.0]],
+        [[0.2, 0.0, 0.0], [0.0, 0.0, 0.0]],
+        [[0.2, 0.0, 0.0], [0.0, 0.0, 0.0]],
+        [[0.3, 0.0, 0.0], [0.0, 0.0, 0.0]],
+    ])
+
+    assert trajectory.coords_are_displacement
+
+
+def test_positions_property(trajectory):
+    trajectory.to_displacements()
+
+    np.testing.assert_allclose(trajectory.positions, [
+        [[0.2, 0.0, 0.0], [0.0, 0.0, 0.5]],
+        [[0.4, 0.0, 0.0], [0.0, 0.0, 0.5]],
+        [[0.6, 0.0, 0.0], [0.0, 0.0, 0.5]],
+        [[0.8, 0.0, 0.0], [0.0, 0.0, 0.5]],
+        [[1.1, 0.0, 0.0], [0.0, 0.0, 0.5]],
+    ])
+
+    assert not trajectory.coords_are_displacement

--- a/tests/trajectory_test.py
+++ b/tests/trajectory_test.py
@@ -6,7 +6,7 @@ from pymatgen.core import Lattice, Species
 def test_trajectory(trajectory):
     assert isinstance(trajectory, Trajectory)
     assert trajectory.species == [Species('B'), Species('C')]
-    assert trajectory.coords.shape == (5, 2, 3)
+    assert trajectory.positions.shape == (5, 2, 3)
     assert trajectory.metadata == {'temperature': 123}
 
 
@@ -15,14 +15,14 @@ def test_slice(trajectory):
 
     assert isinstance(sliced, Trajectory)
     assert sliced.species == trajectory.species
-    assert sliced.coords.shape == (3, 2, 3)
+    assert sliced.positions.shape == (3, 2, 3)
     assert sliced.metadata == trajectory.metadata
 
 
 def test_filter(trajectory):
     t = trajectory.filter('C')
     assert t.species == [Species('C')]
-    assert np.all(t.coords == [.0, .0, .5])
+    assert np.all(t.positions == [.0, .0, .5])
 
 
 def test_get_lattice(trajectory):
@@ -47,7 +47,7 @@ def test_caching(trajectory, tmpdir):
 
     np.testing.assert_allclose(trajectory.lattice, t2.lattice)
     np.testing.assert_allclose(trajectory.base_positions, t2.base_positions)
-    np.testing.assert_allclose(trajectory.coords, t2.coords)
+    np.testing.assert_allclose(trajectory.positions, t2.positions)
 
 
 def test_displacements_property(trajectory):


### PR DESCRIPTION
This PR adds a drift correction method to `Trajectory`.

```python
# Get drift by specifying fixed (framework) species
drift = trajectory.drift(fixed_species=('Br', 'P', 'S'))

# Get drift by specifying floating (diffusing) species
drift = trajectory.drift(floating_species='Li')

# Get a drift corrected trajectory
drift_corrected = trajectory.apply_drift_correction(floating_species='Li')
```

Note: I also added methods for getting displacements / positions explicitly to avoid confusion and having to do the `.to_positions()`/`to_displacements()` dance. `displacements` overlaps with one of the values we calculate (`Displacements` class), so we should consider a different name for that one.

Closes #89