### PR TITLE
Refactor sites into property-like functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,11 @@ plots.plot_vibrational_amplitudes(trajectory)
 
 structure = load_known_material('argyrodite', supercell=(2, 1, 1))
 
-sites = SitesData(structure)
-sites.calculate_all(trajectory=trajectory,
-                    diffusing_element='Li')
+sites = SitesData(
+   structure=structure,
+   trajectory=trajectory,
+   floating_specie='Li',
+)
 
 plots.plot_jumps_vs_distance(trajectory, sites)
 plots.plot_jumps_vs_time(trajectory, sites)
@@ -60,7 +62,7 @@ Or, one function to do everything:
 ```python
 from gemdat.legacy import analyse_md
 
-trajectory, sites, extras = analyse_md(
+trajectory, sites = analyse_md(
    '/data/vasprun.xml',
    diff_elem='Li',
    supercell=(2, 1, 1),

--- a/src/collective.py
+++ b/src/collective.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from functools import lru_cache
+
+import numpy as np
+from pymatgen.core import Lattice, Structure
+
+from .transitions import Transitions
+
+
+class Collective:
+    """Data class for collective jumps.
+
+    Attributes
+    ----------
+    n_solo_jumps : int
+        Number of solo jumps
+    coll_jumps : list[tuple(int, int)]
+        List with start/stop site indices involved in collective jumps
+    collective : list[tuple[int, int]]
+        List of indices to collective jump events
+    """
+
+    def __init__(self,
+                 transitions: Transitions,
+                 structure: Structure,
+                 lattice: Lattice,
+                 max_steps: int,
+                 max_dist: float = 4.5):
+        """Determine number of jumps which could show collective behaviour.
+
+        Parameters
+        ----------
+        transitions : Transitions
+            Input transition events
+        structure : Structure
+            Structure with list of jump sites
+        lattice : Lattice
+            Input lattice for distance calculations (from simulation data)
+        max_steps : int
+            Maximum number of time steps which would still mean correlation
+        max_dist : float
+            Maximum distance for collective motions in Angstrom
+        """
+        self.transitions = transitions
+        self.structure = structure
+        self.lattice = lattice
+        self.max_steps = max_steps
+        self.max_dist = max_dist
+
+        self._compute()
+
+    def _compute(self):
+        """Compute number of jumps which could show collective behaviour."""
+        structure = self.structure
+        lattice = self.lattice
+        max_steps = self.max_steps
+        max_dist = self.max_dist
+
+        time_col = 4
+        events = self.transitions.events
+        event_order = events[:, time_col].argsort()
+
+        coll_jumps = []
+        collective = []
+
+        n_solo_jumps = 0
+
+        for i, event_i in enumerate(event_order[:-1]):
+
+            for j, event_j in enumerate(event_order[i + 1:], start=1):
+
+                atom_i, start_site_i, stop_site_i, _, stop_time_i = events[
+                    event_i]
+                atom_j, start_site_j, stop_site_j, _, stop_time_j = events[
+                    event_j]
+
+                if stop_time_j - stop_time_i > max_steps:
+                    break
+
+                if atom_i == atom_j:
+                    n_solo_jumps += 1
+                    continue
+
+                a = structure.frac_coords[[start_site_i, stop_site_i]]
+                b = structure.frac_coords[[start_site_j, stop_site_j]]
+
+                dists = lattice.get_all_distances(a, b)
+
+                if np.any(dists < max_dist):
+                    collective.append((event_i, event_j))
+                    coll_jumps.append(((start_site_i, stop_site_i),
+                                       (start_site_j, stop_site_j)))
+
+                else:
+                    n_solo_jumps += 1
+
+        self.collective = collective
+        self.coll_jumps = coll_jumps
+        self.n_solo_jumps = n_solo_jumps
+
+    @lru_cache
+    def matrix(self) -> np.ndarray:
+        """Calculate collective jumps matrix.
+
+        Returns
+        -------
+        collective_matrix : np.ndarray
+            Matrix where all types of jumps combinations are counted
+        """
+        labels = self.structure.labels
+        coll_jumps = self.coll_jumps
+
+        site_pairs = list({(label1, label2)
+                           for label1 in labels
+                           for label2 in labels})
+
+        collective_matrix = np.zeros((len(site_pairs), len(site_pairs)),
+                                     dtype=int)
+
+        for ((start_i, stop_i), (start_j, stop_j)) in coll_jumps:
+            name_start_i = labels[start_i]
+            name_stop_i = labels[stop_i]
+            name_start_j = labels[start_j]
+            name_stop_j = labels[stop_j]
+
+            i = site_pairs.index((name_start_i, name_stop_i))
+            j = site_pairs.index((name_start_j, name_stop_j))
+
+            collective_matrix[i, j] += 1
+
+        return collective_matrix
+
+    @lru_cache
+    def multiple_collective(self) -> np.ndarray:
+        """Find jumps that occur collectively multiple times.
+
+        Only returns non-unique jumps
+
+        Returns
+        -------
+        multiple_collective : np.ndarray
+            Dictionary with indices of sites between which jumps happen and their counts.
+        """
+        collective = self.collective
+        coll_sorted = np.sort(np.array(collective).flatten())
+        difference = np.diff(coll_sorted, prepend=0)
+        multiple_collective = coll_sorted[difference == 0]
+
+        return multiple_collective

--- a/src/dashboard/run.py
+++ b/src/dashboard/run.py
@@ -108,11 +108,9 @@ with col2:
               value=f'{metrics.mol_per_liter():g}')
 with col3:
     st.metric('Tracer diffusivity ($\\mathrm{m^2/s}$)',
-              value=f'{metrics.tracer_diffusivity(diffusion_dimensions=3):g}')
-    st.metric(
-        'Tracer conductivity ($\\mathrm{S/m}$)',
-        value=
-        f'{metrics.tracer_conductivity(z_ion=1, diffusion_dimensions=3):g}')
+              value=f'{metrics.tracer_diffusivity(dimensions=3):g}')
+    st.metric('Tracer conductivity ($\\mathrm{S/m}$)',
+              value=f'{metrics.tracer_conductivity(z_ion=1, dimensions=3):g}')
 
 tab1, tab2 = st.tabs(['Default plots', 'RDF plots'])
 
@@ -134,7 +132,7 @@ with tab1:
             trajectory=trajectory,
             diffusing_element=diffusing_element,
             z_ion=1,
-            diffusion_dimensions=3,
+            dimensions=3,
             n_parts=10,
         )
 

--- a/src/dashboard/run.py
+++ b/src/dashboard/run.py
@@ -127,12 +127,10 @@ with tab1:
     st.title('Trajectory and jumps')
 
     with st.spinner('Calculating jumps...'):
-        sites = SitesData(sites_structure)
-        sites.calculate_all(
+        sites = SitesData(
+            structure=sites_structure,
             trajectory=trajectory,
-            diffusing_element=diffusing_element,
-            z_ion=1,
-            dimensions=3,
+            floating_specie=diffusing_element,
             n_parts=10,
         )
 

--- a/src/legacy.py
+++ b/src/legacy.py
@@ -75,14 +75,11 @@ def analyse_md(
 
     sites_structure = load_known_material(material, supercell=supercell)
 
-    sites = SitesData(sites_structure)
-    sites.calculate_all(
+    sites = SitesData(
+        structure=sites_structure,
         trajectory=trajectory,
-        diffusing_element=diff_elem,
-        diffusion_dimensions=diffusion_dimensions,
-        z_ion=z_ion,
+        floating_specie=diff_elem,
         n_parts=nr_parts,
-        dist_collective=dist_collective,
     )
 
     plots.displacement_per_element(trajectory=trajectory)

--- a/src/plots/_jumps.py
+++ b/src/plots/_jumps.py
@@ -43,7 +43,7 @@ def jumps_vs_distance(*,
     counts = np.zeros_like(x)
 
     bin_idx = np.digitize(pdist, bins=x)
-    for idx, n in zip(bin_idx.flatten(), sites.transitions_matrix().flatten()):
+    for idx, n in zip(bin_idx.flatten(), sites.transitions.matrix().flatten()):
         counts[idx] += n
 
     fig, ax = plt.subplots()
@@ -81,7 +81,7 @@ def jumps_vs_time(*,
 
     fig, ax = plt.subplots()
 
-    ax.hist(sites.transition_events()[:, 4], bins=bins, width=0.8 * binsize)
+    ax.hist(sites.transitions.events[:, 4], bins=bins, width=0.8 * binsize)
 
     ax.set(title='Jumps vs. time',
            xlabel='Time (steps)',
@@ -165,8 +165,8 @@ def jumps_3d(*, trajectory: Trajectory, sites: SitesData) -> plt.Figure:
     plotter.plot_points(coords, lattice=lattice, ax=ax)
 
     for i, j in zip(*np.triu_indices(len(coords), k=1)):
-        count = sites.transitions_matrix()[i,
-                                           j] + sites.transitions_matrix()[j,
+        count = sites.transitions.matrix()[i,
+                                           j] + sites.transitions.matrix()[j,
                                                                            i]
         if count == 0:
             continue
@@ -286,9 +286,9 @@ def jumps_3d_animation(*,
     points = ax.collections
 
     time_col = 4
-    event_order = sites.transition_events()[:, time_col].argsort()
+    event_order = sites.transitions.events[:, time_col].argsort()
 
-    events = sites.transition_events()[event_order]
+    events = sites.transitions.events[event_order]
 
     for _, site_i, site_j, *_ in events:
 

--- a/src/plots/_jumps.py
+++ b/src/plots/_jumps.py
@@ -107,7 +107,7 @@ def collective_jumps(*, trajectory: Trajectory,
     """
     fig, ax = plt.subplots()
 
-    mat = ax.imshow(sites.collective_matrix())
+    mat = ax.imshow(sites.collective().matrix())
 
     ticks = range(len(sites.jump_names))
 

--- a/src/plots/_jumps.py
+++ b/src/plots/_jumps.py
@@ -43,7 +43,7 @@ def jumps_vs_distance(*,
     counts = np.zeros_like(x)
 
     bin_idx = np.digitize(pdist, bins=x)
-    for idx, n in zip(bin_idx.flatten(), sites.transitions.flatten()):
+    for idx, n in zip(bin_idx.flatten(), sites.transitions_matrix().flatten()):
         counts[idx] += n
 
     fig, ax = plt.subplots()
@@ -81,7 +81,7 @@ def jumps_vs_time(*,
 
     fig, ax = plt.subplots()
 
-    ax.hist(sites.all_transitions[:, 4], bins=bins, width=0.8 * binsize)
+    ax.hist(sites.transition_events()[:, 4], bins=bins, width=0.8 * binsize)
 
     ax.set(title='Jumps vs. time',
            xlabel='Time (steps)',
@@ -107,7 +107,7 @@ def collective_jumps(*, trajectory: Trajectory,
     """
     fig, ax = plt.subplots()
 
-    mat = ax.imshow(sites.coll_matrix)
+    mat = ax.imshow(sites.collective_matrix())
 
     ticks = range(len(sites.jump_names))
 
@@ -165,7 +165,9 @@ def jumps_3d(*, trajectory: Trajectory, sites: SitesData) -> plt.Figure:
     plotter.plot_points(coords, lattice=lattice, ax=ax)
 
     for i, j in zip(*np.triu_indices(len(coords), k=1)):
-        count = sites.transitions[i, j] + sites.transitions[j, i]
+        count = sites.transitions_matrix()[i,
+                                           j] + sites.transitions_matrix()[j,
+                                                                           i]
         if count == 0:
             continue
 
@@ -284,9 +286,9 @@ def jumps_3d_animation(*,
     points = ax.collections
 
     time_col = 4
-    event_order = sites.all_transitions[:, time_col].argsort()
+    event_order = sites.transition_events()[:, time_col].argsort()
 
-    events = sites.all_transitions[event_order]
+    events = sites.transition_events()[event_order]
 
     for _, site_i, site_j, *_ in events:
 

--- a/src/rdf.py
+++ b/src/rdf.py
@@ -48,12 +48,13 @@ def _get_states(labels: list[str]) -> dict[int, str]:
 
 def _get_states_array(sites: SitesData, labels: list[str]) -> np.ndarray:
     """Helper function to generate integer array of transition states."""
-    atom_sites = _uniqify_labels(sites.atom_sites(), labels)
-    atom_sites_from = _uniqify_labels(sites.atom_sites_from(), labels)
-    atom_sites_to = _uniqify_labels(sites.atom_sites_to(), labels)
+    transitions = sites.transitions
 
-    states_array = (atom_sites * 1e6 + atom_sites_from * 1e3 +
-                    atom_sites_to).astype(int)
+    states = _uniqify_labels(transitions.states, labels)
+    states_prev = _uniqify_labels(transitions.states_prev(), labels)
+    states_next = _uniqify_labels(transitions.states_next(), labels)
+
+    states_array = (states * 1e6 + states_prev * 1e3 + states_next).astype(int)
 
     return states_array
 

--- a/src/rdf.py
+++ b/src/rdf.py
@@ -48,9 +48,9 @@ def _get_states(labels: list[str]) -> dict[int, str]:
 
 def _get_states_array(sites: SitesData, labels: list[str]) -> np.ndarray:
     """Helper function to generate integer array of transition states."""
-    atom_sites = _uniqify_labels(sites.atom_sites, labels)
-    atom_sites_from = _uniqify_labels(sites.atom_sites_from, labels)
-    atom_sites_to = _uniqify_labels(sites.atom_sites_to, labels)
+    atom_sites = _uniqify_labels(sites.atom_sites(), labels)
+    atom_sites_from = _uniqify_labels(sites.atom_sites_from(), labels)
+    atom_sites_to = _uniqify_labels(sites.atom_sites_to(), labels)
 
     states_array = (atom_sites * 1e6 + atom_sites_from * 1e3 +
                     atom_sites_to).astype(int)

--- a/src/simulation_metrics.py
+++ b/src/simulation_metrics.py
@@ -43,14 +43,14 @@ class SimulationMetrics:
         return FloatWithUnit(mol_per_liter, 'mol l^-1')
 
     @lru_cache
-    def tracer_diffusivity(self, *, diffusion_dimensions: int) -> float:
+    def tracer_diffusivity(self, *, dimensions: int) -> float:
         """Return tracer diffusivity in m2/s.
 
         Defined as: MSD/(2*dimensions*time)
 
         Parameters
         ----------
-        diffusion_dimensions : int
+        dimensions : int
             Number of diffusion dimensions
 
         Returns
@@ -60,14 +60,13 @@ class SimulationMetrics:
         distances = self.trajectory.distances_from_base_position()
         msd = np.mean(distances[:, -1]**2)  # Angstrom^2
 
-        tracer_diff = (msd * angstrom**2) / (2 * diffusion_dimensions *
+        tracer_diff = (msd * angstrom**2) / (2 * dimensions *
                                              self.trajectory.total_time)
 
         return FloatWithUnit(tracer_diff, 'm^2 s^-1')
 
     @lru_cache
-    def tracer_conductivity(self, *, z_ion: int,
-                            diffusion_dimensions: int) -> float:
+    def tracer_conductivity(self, *, z_ion: int, dimensions: int) -> float:
         """Return tracer conductivity as S/m.
 
         Defined as: elementary_charge^2 * charge_ion^2 * diffusivity *
@@ -77,7 +76,7 @@ class SimulationMetrics:
         ----------
         z_ion : int
             Charge of the ion
-        diffusion_dimensions : int
+        dimensions : int
             Number of diffusion dimensions
 
         Returns
@@ -85,8 +84,7 @@ class SimulationMetrics:
         tracer_conductivity : float
         """
         temperature = self.trajectory.metadata['temperature']
-        tracer_diff = self.tracer_diffusivity(
-            diffusion_dimensions=diffusion_dimensions)
+        tracer_diff = self.tracer_diffusivity(dimensions=dimensions)
         tracer_conduc = ((elementary_charge**2) * (z_ion**2) * tracer_diff *
                          self.particle_density()) / (Boltzmann * temperature)
 

--- a/src/sites.py
+++ b/src/sites.py
@@ -7,13 +7,13 @@ from functools import lru_cache
 from math import ceil
 
 import numpy as np
-from MDAnalysis.lib.pkdtree import PeriodicKDTree
 from pymatgen.core import Structure
 from pymatgen.core.units import FloatWithUnit
 from scipy.constants import Boltzmann, angstrom, elementary_charge
 
 from .simulation_metrics import SimulationMetrics
-from .utils import bfill, ffill, is_lattice_similar
+from .transitions import Transitions
+from .utils import is_lattice_similar
 
 if typing.TYPE_CHECKING:
 
@@ -24,8 +24,26 @@ NOSITE = -1
 
 class SitesData:
 
-    def __init__(self, *, structure: Structure, trajectory: Trajectory,
-                 floating_specie: str):
+    def __init__(self,
+                 *,
+                 structure: Structure,
+                 trajectory: Trajectory,
+                 floating_specie: str,
+                 n_parts: int = 10):
+        """Contain sites and jumps data.
+
+        Parameters
+        ----------
+        structure : Structure
+            Input structure with known jump sites
+        trajectory : Trajectory
+            Input trajectory
+        floating_specie : str
+            Name of the floating or diffusing specie
+        n_parts : int, optional
+            Number of parts to divide transitions into for statistics
+        """
+        self.n_parts = n_parts
 
         self.floating_specie = floating_specie
         self.structure = structure
@@ -33,12 +51,26 @@ class SitesData:
         self.diff_trajectory = trajectory.filter(floating_specie)
         self.metrics = SimulationMetrics(self.diff_trajectory)
 
-        self.dist_close = self._dist_close()
-
         self.warn_if_lattice_not_similar()
+
+        self.transitions = Transitions.from_trajectory(
+            structure=structure,
+            trajectory=trajectory,
+            floating_specie=floating_specie)
+
+        self.set_split(n_parts)
+
+    def set_split(self, n_parts: int):
+        """Set number to split transitions into for statistics.
+
+        Sets `.parts`.
+        """
+        self.parts = self.transitions.split(n_parts,
+                                            n_steps=len(self.trajectory))
 
     @property
     def site_coords(self):
+        """Return fractional coordinates for known sites."""
         return self.structure.frac_coords
 
     @property
@@ -53,14 +85,17 @@ class SitesData:
 
     @property
     def n_jumps(self):
-        return len(self.transition_events())
+        """Return total number of jumps."""
+        return len(self.transitions.events)
 
     @property
     def n_solo_jumps(self):
+        """Return number of solo jumps."""
         return self.collective()[2]
 
     @property
     def solo_fraction(self):
+        """Fraction of solo jumps."""
         return self.n_solo_jumps / self.n_jumps
 
     def warn_if_lattice_not_similar(self):
@@ -76,181 +111,13 @@ class SitesData:
     def jump_names(self) -> list[str]:
         """Return list of jump names.
 
-        These correspond to the axes in `.coll_matrix`.
+        These correspond to the axes in `.collective_matrix`.
         """
         return ['->'.join(key) for key in self.jumps()]
 
-    def _dist_close(self):
-        """Calculate tolerance wihin which atoms are considered to be close to
-        a site.
-
-        Returns
-        -------
-        dist_close : float
-            Atoms within this distance (in Angstrom) are considered to be close to a site
-        """
-        lattice = self.trajectory.get_lattice()
-        dist_close = 2 * self.metrics.vibration_amplitude()
-
-        pdist = lattice.get_all_distances(self.site_coords, self.site_coords)
-        min_dist = np.min(pdist[np.triu_indices_from(pdist, k=1)])
-
-        if min_dist < 2 * dist_close:
-            # Crystallographic sites are overlapping with the chosen dist_close, making it smaller
-            dist_close = (0.5 * min_dist) - 0.005
-
-            # Two crystallographic sites are within half an Angstrom of each other
-            # This is NOT realistic, check/change the given crystallographic site
-            if dist_close * 2 < 0.5:
-                idx = np.argwhere(pdist == min_dist)
-
-                lines = []
-
-                for i, j in idx:
-                    self.structure.sites[i]
-                    site_j = self.structure.sites[j]
-                    lines.append('\nToo close:')
-                    lines.append(
-                        '{site_i.specie.name}({i}) {site_i.frac_coords} - ')
-                    lines.append(
-                        f'{site_j.specie.name}({j}) {site_j.frac_coords}')
-
-                msg = ''.join(lines)
-
-                raise ValueError(
-                    f'Crystallographic sites are too close together (expected: >{dist_close*2:.4f}, '
-                    f'got: {min_dist:.4f} for {msg}')
-
-        return dist_close
-
-    @lru_cache
-    def atom_sites(self) -> np.ndarray:
-        """Calculate nearest site for each atom coordinate in the trajectory.
-
-        Note: This is a slow operation, because a pairwise distance matrix between all `coords` and
-        all `site_coords` has to be generated. This includes lattice translations. The nearest site
-        may be in the neighbouring unit cell.
-
-        Returns
-        -------
-        atom_sites : np.ndarray
-            Output array with site locations for each atom at each time step [time, atom].
-            The value corresponds to the index in the `site_coords`.
-            -1 indicates that atom is not at any site.
-        """
-        # Unit cell parameters
-        lattice = self.trajectory.get_lattice()
-
-        # Atoms within this distance (in Angstrom) are considered to be close to a site
-        dist_close = self.dist_close
-
-        # Input array with site coordinates [site, (x, y, z)]
-        site_cart_coords = np.dot(self.site_coords, lattice.matrix)
-        site_coords_tree: PeriodicKDTree = PeriodicKDTree(
-            box=np.array(lattice.parameters, dtype=np.float32))
-        site_coords_tree.set_coords(site_cart_coords, cutoff=dist_close)
-
-        atom_sites = []
-
-        for atom_index, atom_coords in enumerate(
-                self.diff_trajectory.positions.swapaxes(0, 1)):
-
-            # index and distance of nearest site
-            atom_cart_coords = np.dot(atom_coords, lattice.matrix)
-            site_index = site_coords_tree.search_tree(atom_cart_coords,
-                                                      dist_close)
-
-            # construct mapping
-            atom_site = np.full((atom_coords.shape[0], 1), NOSITE)
-            for index, site in site_index:
-                atom_site[index] = site
-
-            atom_sites.append(atom_site)
-
-        return np.hstack(atom_sites)
-
-    @lru_cache
-    def atom_sites_from(self) -> np.ndarray:
-        """Calculate atom transition states per time step by forward filling
-        `self.atom_sites`.
-
-        Returns
-        -------
-        atom_sites_from : np.ndarray
-            Output arrays with atom transition states. `atom_sites_from` contains
-            the index of the previous site for every atom.
-        """
-        return ffill(self.atom_sites(), fill_val=NOSITE, axis=0)
-
-    @lru_cache
-    def atom_sites_to(self) -> np.ndarray:
-        """Calculate atom transition states per time step by backward filling
-        `self.atom_sites`.
-
-        Returns
-        -------
-        atom_sites_from, atom_sites_to : np.ndarray
-            Output arrays with atom transition states. `atom_sites_to` contains
-            the index of the next site for every atom.
-        """
-        return bfill(self.atom_sites(), fill_val=NOSITE, axis=0)
-
-    @lru_cache
-    def occupancy(self):
-        """Calculate occupancy per site.
-
-        Returns
-        -------
-        occupancy: dict[int, int]
-            For each site, count for how many time steps it is occupied by an atom
-        """
-        return _calculate_occupancy(self.atom_sites())
-
-    def split(self, *, n_parts: int) -> list[SitesData]:
-        """Split data into equal parts in time for internal statistics.
-
-        Parameters
-        ----------
-        n_parts : int
-            Number of parts to split the data into
-
-        Returns
-        -------
-        parts : list[SitesData]
-            List with `SitesData` object for each part
-        """
-        n_steps = len(self.trajectory)
-
-        split_atom_sites = np.split(self.atom_sites, n_parts)
-        split_transitions = _split_transitions_in_parts(
-            self.transition_events(), n_steps, n_parts)
-
-        parts = [SitesData(self.structure) for _ in range(n_parts)]
-
-        for i, part in enumerate(parts):
-            part.dist_close = self.dist_close
-            part.atom_sites = split_atom_sites[i]
-            part.atom_sites_to = part.atom_sites_to()
-            part.atom_sites_from = part.atom_sites_from()
-
-            part.transition_events = split_transitions[i]
-
-            part.transitions_matrix = part.transitions_matrix()
-
-            part.occupancy = part.occupancy()
-
-            part.site_occupancy = part.site_occupancy(n_steps=int(n_steps /
-                                                                  n_parts))
-
-            part.atom_locations = part.atom_locations()
-
-            part.jumps = part.jumps()
-
-        return parts
-
     @property
     def transitions_parts(self):
-        return np.stack([part.transitions() for part in self.parts])
+        return np.stack([part.matrix() for part in self.parts])
 
     @property
     def occupancy_parts(self):
@@ -258,87 +125,39 @@ class SitesData:
 
     @property
     def site_occupancy_parts(self):
-        return [part.site_occupancy() for part in self.parts]
+        labels = self.structure.labels
+        n_steps = len(self.trajectory)
+
+        parts = self.parts
+
+        return [
+            _calculate_site_occupancy(occupancy=part.occupancy(),
+                                      labels=labels,
+                                      n_steps=n_steps / self.n_parts)
+            for part in parts
+        ]
 
     @property
     def atom_locations_parts(self):
-        return [part.atom_locations() for part in self.parts]
+        multiplier = self.n_sites / self.n_floating
+        return [{
+            k: v * multiplier
+            for k, v in part.items()
+        } for part in self.site_occupancy_parts]
 
     @property
     def jumps_parts(self):
-        return [part.jumps() for part in self.parts]
+        parts = self.parts
 
-    @lru_cache
-    def site_occupancy(self, ) -> dict[str, float]:
-        """Calculate percentage occupancy per unique site.
-
-        Parameters
-        ----------
-        n_steps : int
-            Number of steps in time series
-
-        Returns
-        -------
-        site_occopancy : dict[str, float]
-            Percentage occupancy per unique site
-        """
-        n_steps = len(self.trajectory)
         labels = self.structure.labels
-        return _calculate_site_occupancy(occupancy=self.occupancy(),
-                                         labels=labels,
-                                         n_steps=n_steps)
+        jumps_parts = []
 
-    @lru_cache
-    def atom_locations(self) -> dict[str, float]:
-        """Calculate fraction of time atoms spent at a type of site.
+        for part in parts:
+            jumps = Counter([(labels[i], labels[j])
+                             for i, j in part.events[:, 1:3]])
+            jumps_parts.append(jumps)
 
-        Returns
-        -------
-        dict[str, float]
-            Return dict with the fraction of time atoms spent at a site
-        """
-        multiplier = self.n_sites / self.n_floating
-        return {k: v * multiplier for k, v in self.site_occupancy().items()}
-
-    @lru_cache
-    def transition_events(self):
-        """Find transitions between sites.
-
-        Returns
-        -------
-        transition_events : np.ndarray
-            Output array with transition events.
-            Contains 5 columns: atom index, time start, time stop, site start, site stop
-        """
-        return _calculate_transition_events(atom_sites=self.atom_sites())
-
-    @lru_cache
-    def transitions_matrix(self):
-        """Convert list of transition events to dense transitions matrix.
-
-        Returns
-        -------
-        transitions_matrix : np.ndarray
-            Square matrix with number of each transitions
-        """
-        return _calculate_transitions_matrix(self.transition_events(),
-                                             n_sites=self.n_sites)
-
-    @lru_cache
-    def jumps(self) -> dict[tuple[str, str], int]:
-        """Calculate number of jumpst between sites.
-
-        Returns
-        -------
-        jumps : dict[tuple[str, str], int]
-            Dictionary with number of jumpst per sites combination
-        """
-        labels = self.structure.labels
-
-        jumps = Counter([(labels[i], labels[j])
-                         for i, j in self.transition_events()[:, 1:3]])
-
-        return jumps
+        return jumps_parts
 
     @lru_cache
     def rates(self) -> dict[tuple[str, str], tuple[float, float]]:
@@ -351,7 +170,7 @@ class SitesData:
         """
         rates: dict[tuple[str, str], tuple[float, float]] = {}
 
-        n_parts = len(self.parts)
+        n_parts = self.n_parts
 
         for site_pair in self.jumps():
             n_jumps = [part[site_pair] for part in self.jumps_parts]
@@ -371,11 +190,6 @@ class SitesData:
             self) -> dict[tuple[str, str], tuple[float, float]]:
         """Calculate activation energies for jumps (UNITS?).
 
-        Parameters
-        ----------
-        attempt_freq : float
-            Jump attempt frequency
-
         Returns
         -------
         e_act : dict[tuple[str, str], tuple[float, float]]
@@ -385,7 +199,7 @@ class SitesData:
 
         e_act = {}
 
-        n_parts = len(self.parts)
+        n_parts = self.n_parts
 
         temperature = self.trajectory.metadata['temperature']
 
@@ -414,6 +228,46 @@ class SitesData:
 
         return e_act
 
+    def site_occupancy(self):
+        """Calculate percentage occupancy per unique site.
+
+        Returns
+        -------
+        site_occopancy : dict[str, float]
+            Percentage occupancy per unique site
+        """
+        labels = self.structure.labels
+        n_steps = len(self.trajectory)
+        return _calculate_site_occupancy(
+            occupancy=self.transitions.occupancy(),
+            labels=labels,
+            n_steps=n_steps)
+
+    def atom_locations(self):
+        """Calculate fraction of time atoms spent at a type of site.
+
+        Returns
+        -------
+        dict[str, float]
+            Return dict with the fraction of time atoms spent at a site
+        """
+        multiplier = self.n_sites / self.n_floating
+        return {k: v * multiplier for k, v in self.site_occupancy().items()}
+
+    def jumps(self, ):
+        """Calculate number of jumpst between sites.
+
+        Returns
+        -------
+        jumps : dict[tuple[str, str], int]
+            Dictionary with number of jumpst per sites combination
+        """
+        labels = self.structure.labels
+        jumps = Counter([(labels[i], labels[j])
+                         for i, j in self.transitions.events[:, 1:3]])
+
+        return jumps
+
     @lru_cache
     def jump_diffusivity(self, dimensions: int) -> float:
         """Calculate jump diffusivity.
@@ -435,7 +289,7 @@ class SitesData:
         pdist = lattice.get_all_distances(structure.frac_coords,
                                           structure.frac_coords)
 
-        jump_diff = np.sum(pdist**2 * self.transitions_matrix())
+        jump_diff = np.sum(pdist**2 * self.transitions.matrix())
         jump_diff *= angstrom**2 / (2 * dimensions * self.n_floating *
                                     total_time)
 
@@ -467,7 +321,7 @@ class SitesData:
         coll_steps = ceil(1.0 / (attempt_freq * time_step))
 
         time_col = 4
-        events = self.transition_events()
+        events = self.transitions.events
         event_order = events[:, time_col].argsort()
 
         coll_jumps = []
@@ -554,132 +408,6 @@ class SitesData:
         multi_coll = coll_sorted[difference == 0]
 
         return multi_coll
-
-
-def _calculate_transition_events(*, atom_sites: np.ndarray) -> np.ndarray:
-    """Find transitions between sites.
-
-    Parameters
-    ----------
-    atom_sites : np.ndarray
-        Input array with atom sites
-
-    Returns
-    -------
-    transition_events : np.ndarray
-        Output array with transition events.
-        Contains 5 columns: atom index, time start, time stop, site start, site stop
-    """
-    transition_events = []
-
-    for atom_index, atom_site in enumerate(atom_sites.T):
-
-        # Indices when atom jumps to new or back to same site
-        i, = np.nonzero((atom_site != np.roll(atom_site, shift=1))
-                        & (atom_site >= 0))
-
-        # Log transition events
-        i_event = np.nonzero(atom_site[i] != np.roll(atom_site[i], shift=-1))
-        time_start = i[i_event]
-        time_stop = np.roll(i, shift=-1)[i_event]
-        transitions = np.vstack([
-            np.ones_like(time_start) * atom_index,
-            atom_site[time_start],
-            atom_site[time_stop],
-            time_start,
-            time_stop,
-        ]).T
-
-        # Drop last event (side effect of np.roll)
-        transitions = transitions[:-1]
-        transition_events.append(transitions)
-
-    return np.vstack(transition_events)
-
-
-def _calculate_transitions_matrix(transition_events: np.ndarray,
-                                  n_sites: int) -> np.ndarray:
-    """Convert list of transition events to dense transitions matrix.
-
-    Parameters
-    ----------
-    transition_events : np.ndarray
-        Input array with transition events
-    n_sites : int
-        Number of jump sites for diffusing element. This defines the shape of the output matrix.
-
-    Returns
-    -------
-    np.ndarray
-        Square matrix with number of each transitions
-    """
-    start_col = 1  # transition starts
-    stop_col = 2  # transition stop
-
-    transitions = np.zeros((n_sites, n_sites), dtype=int)
-    idx, counts = np.unique(transition_events[:, [start_col, stop_col]],
-                            return_counts=True,
-                            axis=0)
-    start_idx, stop_idx = idx.T
-    transitions[start_idx, stop_idx] = counts
-    return transitions
-
-
-def _split_transitions_in_parts(transition_events: np.ndarray,
-                                n_steps: int,
-                                n_parts=10) -> list[np.ndarray]:
-    """Split list of transition events into equal parts in time.
-
-    Parameters
-    ----------
-    transition_events : np.ndarray
-        Input array with transition events
-    n_steps : int
-        Number of time steps
-    n_parts : int, optional
-        Number of parts to split into
-
-    Returns
-    -------
-    transitions_parts : np.ndarray
-        Sorted list of transition events split into equal parts.
-        The first dimension corresponds to `n_parts`.
-    """
-    col = 4
-
-    bins = np.linspace(0, n_steps + 1, n_parts + 1, dtype=int)
-    parts = np.digitize(transition_events[:, col], bins=bins)
-    parts = parts[parts.argsort()]
-    splits = np.unique(parts, return_index=True)[1][1:]
-
-    sorted_transitions = transition_events[transition_events[:, col].argsort()]
-
-    parts = np.split(sorted_transitions, splits)
-
-    if len(parts) < n_parts:
-        raise ValueError(
-            f'Not enough transitions per part to split into {n_parts}')
-
-    return parts
-
-
-def _calculate_occupancy(atom_sites: np.ndarray) -> dict[int, int]:
-    """Calculate occupancy per site.
-
-    Parameters
-    ----------
-    atom_sites : np.ndarray
-        Input array with atom sites
-
-    Returns
-    -------
-    occupancy : dict[int, int]
-        For each site, count for how many time steps it is occupied by an atom
-    """
-    unq, counts = np.unique(atom_sites, return_counts=True)
-    occupancy = dict(zip(unq, counts))
-    occupancy.pop(NOSITE, None)
-    return occupancy
 
 
 def _calculate_site_occupancy(*, occupancy: dict[int, int], labels: list[str],

--- a/src/sites.py
+++ b/src/sites.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import typing
 import warnings
 from collections import Counter, defaultdict
+from functools import lru_cache
+from math import ceil
 
 import numpy as np
 from MDAnalysis.lib.pkdtree import PeriodicKDTree
-from pymatgen.core import Lattice, Structure
+from pymatgen.core import Structure
 from pymatgen.core.units import FloatWithUnit
 from scipy.constants import Boltzmann, angstrom, elementary_charge
 
@@ -22,126 +24,53 @@ NOSITE = -1
 
 class SitesData:
 
-    def __init__(self, structure: Structure):
+    def __init__(self, *, structure: Structure, trajectory: Trajectory,
+                 floating_specie: str):
+
+        self.floating_specie = floating_specie
         self.structure = structure
+        self.trajectory = trajectory
+        self.diff_trajectory = trajectory.filter(floating_specie)
+        self.metrics = SimulationMetrics(self.diff_trajectory)
+
+        self.dist_close = self._dist_close()
+
+        self.warn_if_lattice_not_similar()
 
     @property
     def site_coords(self):
         return self.structure.frac_coords
 
     @property
-    def succes(self):
-        """Alias for `self.transitions_parts`."""
-        return self.transitions_parts
-
-    @property
     def n_sites(self):
         """Return number of sites."""
         return len(self.structure)
 
-    def warn_if_lattice_not_similar(self, other_lattice: Lattice):
+    @property
+    def n_floating(self):
+        """Return number of floating species."""
+        return len(self.diff_trajectory.species)
+
+    @property
+    def n_jumps(self):
+        return len(self.transition_events())
+
+    @property
+    def n_solo_jumps(self):
+        return self.collective()[2]
+
+    @property
+    def solo_fraction(self):
+        return self.n_solo_jumps / self.n_jumps
+
+    def warn_if_lattice_not_similar(self):
+        """Raise warning if structure and trajectory lattices do not match."""
         this_lattice = self.structure.lattice
+        other_lattice = self.trajectory.get_lattice()
 
         if not is_lattice_similar(other_lattice, this_lattice):
             warnings.warn(f'Lattice mismatch: {this_lattice.parameters} '
                           f'vs. {other_lattice.parameters}')
-
-    def calculate_all(
-        self,
-        trajectory: Trajectory,
-        *,
-        diffusing_element: str,
-        z_ion: int = 1,
-        diffusion_dimensions: int = 3,
-        dist_collective: float = 4.5,
-        n_parts: int = 1,
-    ):
-        """Calculate all parameters.
-
-        Parameters
-        ----------
-        trajectory : Trajectory
-            Input trajectory
-        diffusing_element : str
-            Name of the diffusing species
-        z_ion : int
-            Ionic charge of difussing species
-        diffusion_dimensions : int
-            Number of diffusion dimensions
-        n_parts : int
-            Number of parts to divide simulation into for statistics
-        """
-        lattice = trajectory.get_lattice()
-
-        self.warn_if_lattice_not_similar(lattice)
-
-        diff_trajectory = trajectory.filter(diffusing_element)
-        n_diffusing = len(diff_trajectory.species)
-        n_steps = len(diff_trajectory)
-
-        metrics = SimulationMetrics(diff_trajectory)
-
-        self.dist_close = self.calculate_dist_close(
-            trajectory, vibration_amplitude=metrics.vibration_amplitude())
-
-        self.atom_sites = self.calculate_atom_sites(diff_trajectory)
-        self.atom_sites_from = self.calculate_atom_sites_from()
-        self.atom_sites_to = self.calculate_atom_sites_to()
-
-        self.all_transitions = self.calculate_transition_events()
-
-        self.transitions = self.calculate_transitions_matrix()
-
-        self.occupancy = self.calculate_occupancy()
-
-        self.sites_occupancy = self.calculate_site_occupancy(n_steps=n_steps)
-
-        self.atom_locations = self.calculate_atom_locations(
-            n_diffusing=n_diffusing)
-
-        self.jumps = self.calculate_jumps()
-        self.n_jumps = len(self.all_transitions)
-
-        self.jump_diffusivity = self.calculate_jump_diffusivity(
-            lattice=lattice,
-            n_diffusing=n_diffusing,
-            total_time=trajectory.total_time,
-            dimensions=diffusion_dimensions)
-        tracer_diff = metrics.tracer_diffusivity(
-            diffusion_dimensions=diffusion_dimensions)
-        self.correlation_factor = tracer_diff / self.jump_diffusivity
-
-        attempt_freq, _ = metrics.attempt_frequency()
-
-        self.collective, self.coll_jumps, self.n_solo_jumps = self.calculate_collective(
-            lattice=lattice,
-            attempt_freq=attempt_freq,
-            time_step=trajectory.time_step,
-            dist_collective=dist_collective,
-        )
-
-        self.solo_frac = self.n_solo_jumps / len(self.all_transitions)
-        self.coll_count = len(self.collective)
-
-        self.coll_matrix = self.calculate_collective_matrix()
-        self.multi_coll = self.calculate_multiple_collective()
-
-        # calculate some statistics
-        if n_parts > 1:
-            self.parts = self.split(
-                n_parts=n_parts,
-                n_steps=n_steps,
-                n_diffusing=n_diffusing,
-            )
-
-            self.rates = self.calculate_rates(total_time=trajectory.total_time,
-                                              n_diffusing=n_diffusing)
-
-            self.activation_energies = self.calculate_activation_energies(
-                total_time=trajectory.total_time,
-                n_diffusing=n_diffusing,
-                attempt_freq=attempt_freq,
-                temperature=trajectory.metadata['temperature'])
 
     @property
     def jump_names(self) -> list[str]:
@@ -149,27 +78,19 @@ class SitesData:
 
         These correspond to the axes in `.coll_matrix`.
         """
-        return ['->'.join(key) for key in self.jumps]
+        return ['->'.join(key) for key in self.jumps()]
 
-    def calculate_dist_close(self, trajectory: Trajectory,
-                             vibration_amplitude: float):
+    def _dist_close(self):
         """Calculate tolerance wihin which atoms are considered to be close to
         a site.
-
-        Parameters
-        ----------
-        trajectory : Trajectory
-            Input trajectory
-        vibration_amplitude : float
-            Vibration amplitude
 
         Returns
         -------
         dist_close : float
             Atoms within this distance (in Angstrom) are considered to be close to a site
         """
-        lattice = trajectory.get_lattice()
-        dist_close = 2 * vibration_amplitude
+        lattice = self.trajectory.get_lattice()
+        dist_close = 2 * self.metrics.vibration_amplitude()
 
         pdist = lattice.get_all_distances(self.site_coords, self.site_coords)
         min_dist = np.min(pdist[np.triu_indices_from(pdist, k=1)])
@@ -202,17 +123,13 @@ class SitesData:
 
         return dist_close
 
-    def calculate_atom_sites(self, trajectory: Trajectory) -> np.ndarray:
+    @lru_cache
+    def atom_sites(self) -> np.ndarray:
         """Calculate nearest site for each atom coordinate in the trajectory.
 
         Note: This is a slow operation, because a pairwise distance matrix between all `coords` and
         all `site_coords` has to be generated. This includes lattice translations. The nearest site
         may be in the neighbouring unit cell.
-
-        Parameters
-        ----------
-        trajectory : Trajectory
-            Input trajectory (e.g. for diffusing species)
 
         Returns
         -------
@@ -222,7 +139,7 @@ class SitesData:
             -1 indicates that atom is not at any site.
         """
         # Unit cell parameters
-        lattice = trajectory.get_lattice()
+        lattice = self.trajectory.get_lattice()
 
         # Atoms within this distance (in Angstrom) are considered to be close to a site
         dist_close = self.dist_close
@@ -236,7 +153,7 @@ class SitesData:
         atom_sites = []
 
         for atom_index, atom_coords in enumerate(
-                trajectory.positions.swapaxes(0, 1)):
+                self.diff_trajectory.positions.swapaxes(0, 1)):
 
             # index and distance of nearest site
             atom_cart_coords = np.dot(atom_coords, lattice.matrix)
@@ -252,7 +169,8 @@ class SitesData:
 
         return np.hstack(atom_sites)
 
-    def calculate_atom_sites_from(self) -> np.ndarray:
+    @lru_cache
+    def atom_sites_from(self) -> np.ndarray:
         """Calculate atom transition states per time step by forward filling
         `self.atom_sites`.
 
@@ -262,9 +180,10 @@ class SitesData:
             Output arrays with atom transition states. `atom_sites_from` contains
             the index of the previous site for every atom.
         """
-        return ffill(self.atom_sites, fill_val=NOSITE, axis=0)
+        return ffill(self.atom_sites(), fill_val=NOSITE, axis=0)
 
-    def calculate_atom_sites_to(self) -> np.ndarray:
+    @lru_cache
+    def atom_sites_to(self) -> np.ndarray:
         """Calculate atom transition states per time step by backward filling
         `self.atom_sites`.
 
@@ -274,9 +193,10 @@ class SitesData:
             Output arrays with atom transition states. `atom_sites_to` contains
             the index of the next site for every atom.
         """
-        return bfill(self.atom_sites, fill_val=NOSITE, axis=0)
+        return bfill(self.atom_sites(), fill_val=NOSITE, axis=0)
 
-    def calculate_occupancy(self):
+    @lru_cache
+    def occupancy(self):
         """Calculate occupancy per site.
 
         Returns
@@ -284,75 +204,72 @@ class SitesData:
         occupancy: dict[int, int]
             For each site, count for how many time steps it is occupied by an atom
         """
-        return _calculate_occupancy(self.atom_sites)
+        return _calculate_occupancy(self.atom_sites())
 
-    def split(self, *, n_parts: int, n_steps: int,
-              n_diffusing: int) -> list[SitesData]:
+    def split(self, *, n_parts: int) -> list[SitesData]:
         """Split data into equal parts in time for internal statistics.
 
         Parameters
         ----------
         n_parts : int
             Number of parts to split the data into
-        n_steps : int
-            Number of steps in the trajectory
-        n_diffusing : int
-            Number of diffusing species
 
         Returns
         -------
         parts : list[SitesData]
             List with `SitesData` object for each part
         """
+        n_steps = len(self.trajectory)
+
         split_atom_sites = np.split(self.atom_sites, n_parts)
         split_transitions = _split_transitions_in_parts(
-            self.all_transitions, n_steps, n_parts)
+            self.transition_events(), n_steps, n_parts)
 
         parts = [SitesData(self.structure) for _ in range(n_parts)]
 
         for i, part in enumerate(parts):
             part.dist_close = self.dist_close
             part.atom_sites = split_atom_sites[i]
-            part.atom_sites_to = part.calculate_atom_sites_to()
-            part.atom_sites_from = part.calculate_atom_sites_from()
+            part.atom_sites_to = part.atom_sites_to()
+            part.atom_sites_from = part.atom_sites_from()
 
-            part.all_transitions = split_transitions[i]
+            part.transition_events = split_transitions[i]
 
-            part.transitions = part.calculate_transitions_matrix()
+            part.transitions_matrix = part.transitions_matrix()
 
-            part.occupancy = part.calculate_occupancy()
+            part.occupancy = part.occupancy()
 
-            part.sites_occupancy = part.calculate_site_occupancy(
-                n_steps=int(n_steps / n_parts))
+            part.site_occupancy = part.site_occupancy(n_steps=int(n_steps /
+                                                                  n_parts))
 
-            part.atom_locations = part.calculate_atom_locations(
-                n_diffusing=n_diffusing)
+            part.atom_locations = part.atom_locations()
 
-            part.jumps = part.calculate_jumps()
+            part.jumps = part.jumps()
 
         return parts
 
     @property
     def transitions_parts(self):
-        return np.stack([part.transitions for part in self.parts])
+        return np.stack([part.transitions() for part in self.parts])
 
     @property
     def occupancy_parts(self):
-        return [part.occupancy for part in self.parts]
+        return [part.occupancy() for part in self.parts]
 
     @property
-    def sites_occupancy_parts(self):
-        return [part.sites_occupancy for part in self.parts]
+    def site_occupancy_parts(self):
+        return [part.site_occupancy() for part in self.parts]
 
     @property
     def atom_locations_parts(self):
-        return [part.atom_locations for part in self.parts]
+        return [part.atom_locations() for part in self.parts]
 
     @property
     def jumps_parts(self):
-        return [part.jumps for part in self.parts]
+        return [part.jumps() for part in self.parts]
 
-    def calculate_site_occupancy(self, *, n_steps: int) -> dict[str, float]:
+    @lru_cache
+    def site_occupancy(self, ) -> dict[str, float]:
         """Calculate percentage occupancy per unique site.
 
         Parameters
@@ -365,39 +282,38 @@ class SitesData:
         site_occopancy : dict[str, float]
             Percentage occupancy per unique site
         """
+        n_steps = len(self.trajectory)
         labels = self.structure.labels
-        return _calculate_site_occupancy(occupancy=self.occupancy,
+        return _calculate_site_occupancy(occupancy=self.occupancy(),
                                          labels=labels,
                                          n_steps=n_steps)
 
-    def calculate_atom_locations(self, n_diffusing: int) -> dict[str, float]:
+    @lru_cache
+    def atom_locations(self) -> dict[str, float]:
         """Calculate fraction of time atoms spent at a type of site.
-
-        Parameters
-        ----------
-        n_diffusing : int
-            Number of diffusing atoms
 
         Returns
         -------
         dict[str, float]
             Return dict with the fraction of time atoms spent at a site
         """
-        multiplier = self.n_sites / n_diffusing
-        return {k: v * multiplier for k, v in self.sites_occupancy.items()}
+        multiplier = self.n_sites / self.n_floating
+        return {k: v * multiplier for k, v in self.site_occupancy().items()}
 
-    def calculate_transition_events(self):
+    @lru_cache
+    def transition_events(self):
         """Find transitions between sites.
 
         Returns
         -------
-        all_transitions : np.ndarray
+        transition_events : np.ndarray
             Output array with transition events.
             Contains 5 columns: atom index, time start, time stop, site start, site stop
         """
-        return _calculate_transition_events(atom_sites=self.atom_sites)
+        return _calculate_transition_events(atom_sites=self.atom_sites())
 
-    def calculate_transitions_matrix(self):
+    @lru_cache
+    def transitions_matrix(self):
         """Convert list of transition events to dense transitions matrix.
 
         Returns
@@ -405,10 +321,11 @@ class SitesData:
         transitions_matrix : np.ndarray
             Square matrix with number of each transitions
         """
-        return _calculate_transitions_matrix(self.all_transitions,
+        return _calculate_transitions_matrix(self.transition_events(),
                                              n_sites=self.n_sites)
 
-    def calculate_jumps(self) -> dict[tuple[str, str], int]:
+    @lru_cache
+    def jumps(self) -> dict[tuple[str, str], int]:
         """Calculate number of jumpst between sites.
 
         Returns
@@ -419,21 +336,13 @@ class SitesData:
         labels = self.structure.labels
 
         jumps = Counter([(labels[i], labels[j])
-                         for i, j in self.all_transitions[:, 1:3]])
+                         for i, j in self.transition_events()[:, 1:3]])
 
         return jumps
 
-    def calculate_rates(
-            self, *, total_time: float,
-            n_diffusing: int) -> dict[tuple[str, str], tuple[float, float]]:
+    @lru_cache
+    def rates(self) -> dict[tuple[str, str], tuple[float, float]]:
         """Calculate jump rates (total jumps / second).
-
-        Parameters
-        ----------
-        total_time : float
-            Total time for the simulation
-        n_diffusing : int
-            Number of diffusing atoms
 
         Returns
         -------
@@ -444,11 +353,11 @@ class SitesData:
 
         n_parts = len(self.parts)
 
-        for site_pair in self.jumps:
+        for site_pair in self.jumps():
             n_jumps = [part[site_pair] for part in self.jumps_parts]
 
-            part_time = total_time / n_parts
-            denom = n_diffusing * part_time
+            part_time = self.trajectory.total_time / n_parts
+            denom = self.n_floating * part_time
 
             jump_freq_mean = np.mean(n_jumps) / denom
             jump_freq_std = np.std(n_jumps, ddof=1) / denom
@@ -457,41 +366,39 @@ class SitesData:
 
         return rates
 
-    def calculate_activation_energies(
-            self, *, total_time: float, n_diffusing: int, attempt_freq: float,
-            temperature: float) -> dict[tuple[str, str], tuple[float, float]]:
+    @lru_cache
+    def activation_energies(
+            self) -> dict[tuple[str, str], tuple[float, float]]:
         """Calculate activation energies for jumps (UNITS?).
 
         Parameters
         ----------
-        total_time : float
-            Total time for the simulation
-        n_diffusing : int
-            Number of diffusing atoms
         attempt_freq : float
             Jump attempt frequency
-        temperature : float
-            Temperature of the simulation
 
         Returns
         -------
         e_act : dict[tuple[str, str], tuple[float, float]]
             Dictionary with jump activation energies and standard deviations between site pairs.
         """
+        attempt_freq, _ = self.metrics.attempt_frequency()
+
         e_act = {}
 
         n_parts = len(self.parts)
 
-        for i, site_pair in enumerate(self.jumps):
+        temperature = self.trajectory.metadata['temperature']
+
+        for i, site_pair in enumerate(self.jumps()):
             site_start, site_stop = site_pair
 
             n_jumps = np.array([part[site_pair] for part in self.jumps_parts])
 
-            part_time = total_time / n_parts
+            part_time = self.trajectory.total_time / n_parts
 
             atom_percentage = self.atom_locations_parts[i][site_start]
 
-            denom = atom_percentage * n_diffusing * part_time
+            denom = atom_percentage * self.n_floating * part_time
 
             eff_rate = n_jumps / denom
 
@@ -507,19 +414,12 @@ class SitesData:
 
         return e_act
 
-    def calculate_jump_diffusivity(self, lattice: Lattice, n_diffusing: int,
-                                   total_time: float,
-                                   dimensions: int) -> float:
+    @lru_cache
+    def jump_diffusivity(self, dimensions: int) -> float:
         """Calculate jump diffusivity.
 
         Parameters
         ----------
-        lattice : Lattice
-            Lattice of the simulation data
-        n_diffusing : int
-            Number of diffusing elements
-        total_time : float
-            Total simulation time
         dimensions : int
             Number of diffusion dimensions
 
@@ -528,34 +428,28 @@ class SitesData:
         jump_diff : float
             Jump diffusivity in m^2/s
         """
+        lattice = self.trajectory.get_lattice()
         structure = self.structure
+        total_time = self.trajectory.total_time
 
         pdist = lattice.get_all_distances(structure.frac_coords,
                                           structure.frac_coords)
 
-        jump_diff = np.sum(pdist**2 * self.transitions)
-        jump_diff *= angstrom**2 / (2 * dimensions * n_diffusing * total_time)
+        jump_diff = np.sum(pdist**2 * self.transitions_matrix())
+        jump_diff *= angstrom**2 / (2 * dimensions * self.n_floating *
+                                    total_time)
 
         jump_diff = FloatWithUnit(jump_diff, 'm^2 s^-1')
 
         return jump_diff
 
-    def calculate_collective(
-            self,
-            lattice: Lattice,
-            attempt_freq: float,
-            time_step: float,
-            dist_collective: float = 4.5) -> tuple[list, list, int]:
+    @lru_cache
+    def collective(self,
+                   dist_collective: float = 4.5) -> tuple[list, list, int]:
         """Calculate collective jumps.
 
         Parameters
         ----------
-        lattice : Lattice
-            Lattice for distance calculations
-        attempt_freq : float
-            Attempt frequency in ...
-        time_step : float
-            Time step in seconds
         dist_collective : float, optional
             Maximum distance for collective motions in Angstrom
 
@@ -566,11 +460,14 @@ class SitesData:
             coll_jumps, list with start/stop site indices involved in collective jumps
             n_solo_jumps, number of solo jumps
         """
-        from math import ceil
+        lattice = self.trajectory.get_lattice()
+        time_step = self.trajectory.time_step
+        attempt_freq, _ = self.metrics.attempt_frequency()
+
         coll_steps = ceil(1.0 / (attempt_freq * time_step))
 
         time_col = 4
-        events = self.all_transitions
+        events = self.transition_events()
         event_order = events[:, time_col].argsort()
 
         coll_jumps = []
@@ -611,7 +508,8 @@ class SitesData:
 
         return collective, coll_jumps, n_solo_jumps
 
-    def calculate_collective_matrix(self) -> np.ndarray:
+    @lru_cache
+    def collective_matrix(self) -> np.ndarray:
         """Calculate collective jumps matrix.
 
         Returns
@@ -620,12 +518,13 @@ class SitesData:
             Matrix where all types of jumps combinations are counted
         """
         labels = self.structure.labels
+        _, coll_jumps, _ = self.collective()
 
-        jump_names = list(self.jumps)
+        jump_names = list(self.jumps())
 
         coll_matrix = np.zeros((len(jump_names), len(jump_names)), dtype=int)
 
-        for ((start_i, stop_i), (start_j, stop_j)) in self.coll_jumps:
+        for ((start_i, stop_i), (start_j, stop_j)) in coll_jumps:
             name_start_i = labels[start_i]
             name_stop_i = labels[stop_i]
             name_start_j = labels[start_j]
@@ -638,7 +537,8 @@ class SitesData:
 
         return coll_matrix
 
-    def calculate_multiple_collective(self) -> np.ndarray:
+    @lru_cache
+    def multiple_collective(self) -> np.ndarray:
         """Find jumps that occur collectively multiple times.
 
         Only returns non-unique jumps
@@ -648,7 +548,8 @@ class SitesData:
         multi_coll : np.ndarray
             Dictionary with indices of sites between which jumps happen and their counts.
         """
-        coll_sorted = np.sort(np.array(self.collective).flatten())
+        collective, *_ = self.collective()
+        coll_sorted = np.sort(np.array(collective).flatten())
         difference = np.diff(coll_sorted, prepend=0)
         multi_coll = coll_sorted[difference == 0]
 
@@ -665,11 +566,11 @@ def _calculate_transition_events(*, atom_sites: np.ndarray) -> np.ndarray:
 
     Returns
     -------
-    all_transitions : np.ndarray
+    transition_events : np.ndarray
         Output array with transition events.
         Contains 5 columns: atom index, time start, time stop, site start, site stop
     """
-    all_transitions = []
+    transition_events = []
 
     for atom_index, atom_site in enumerate(atom_sites.T):
 
@@ -691,18 +592,18 @@ def _calculate_transition_events(*, atom_sites: np.ndarray) -> np.ndarray:
 
         # Drop last event (side effect of np.roll)
         transitions = transitions[:-1]
-        all_transitions.append(transitions)
+        transition_events.append(transitions)
 
-    return np.vstack(all_transitions)
+    return np.vstack(transition_events)
 
 
-def _calculate_transitions_matrix(all_transitions: np.ndarray,
+def _calculate_transitions_matrix(transition_events: np.ndarray,
                                   n_sites: int) -> np.ndarray:
     """Convert list of transition events to dense transitions matrix.
 
     Parameters
     ----------
-    all_transitions : np.ndarray
+    transition_events : np.ndarray
         Input array with transition events
     n_sites : int
         Number of jump sites for diffusing element. This defines the shape of the output matrix.
@@ -716,7 +617,7 @@ def _calculate_transitions_matrix(all_transitions: np.ndarray,
     stop_col = 2  # transition stop
 
     transitions = np.zeros((n_sites, n_sites), dtype=int)
-    idx, counts = np.unique(all_transitions[:, [start_col, stop_col]],
+    idx, counts = np.unique(transition_events[:, [start_col, stop_col]],
                             return_counts=True,
                             axis=0)
     start_idx, stop_idx = idx.T
@@ -724,14 +625,14 @@ def _calculate_transitions_matrix(all_transitions: np.ndarray,
     return transitions
 
 
-def _split_transitions_in_parts(all_transitions: np.ndarray,
+def _split_transitions_in_parts(transition_events: np.ndarray,
                                 n_steps: int,
                                 n_parts=10) -> list[np.ndarray]:
     """Split list of transition events into equal parts in time.
 
     Parameters
     ----------
-    all_transitions : np.ndarray
+    transition_events : np.ndarray
         Input array with transition events
     n_steps : int
         Number of time steps
@@ -747,11 +648,11 @@ def _split_transitions_in_parts(all_transitions: np.ndarray,
     col = 4
 
     bins = np.linspace(0, n_steps + 1, n_parts + 1, dtype=int)
-    parts = np.digitize(all_transitions[:, col], bins=bins)
+    parts = np.digitize(transition_events[:, col], bins=bins)
     parts = parts[parts.argsort()]
     splits = np.unique(parts, return_index=True)[1][1:]
 
-    sorted_transitions = all_transitions[all_transitions[:, col].argsort()]
+    sorted_transitions = transition_events[transition_events[:, col].argsort()]
 
     parts = np.split(sorted_transitions, splits)
 

--- a/src/transitions.py
+++ b/src/transitions.py
@@ -1,0 +1,358 @@
+from __future__ import annotations
+
+import typing
+from functools import lru_cache
+
+import numpy as np
+from MDAnalysis.lib.pkdtree import PeriodicKDTree
+from pymatgen.core import Structure
+
+from .simulation_metrics import SimulationMetrics
+from .utils import bfill, ffill
+
+if typing.TYPE_CHECKING:
+
+    from gemdat.trajectory import Trajectory
+
+NOSITE = -1
+
+
+class Transitions:
+
+    def __init__(self, events: np.ndarray, states: np.ndarray, n_sites: int):
+
+        self.states = states
+        self.events = events
+        self.n_sites = n_sites
+
+    @classmethod
+    def from_trajectory(cls, *, trajectory: Trajectory, structure: Structure,
+                        floating_specie: str):
+        diff_trajectory = trajectory.filter(floating_specie)
+        vibration_amplitude = SimulationMetrics(
+            diff_trajectory).vibration_amplitude()
+
+        dist_close = _dist_close(trajectory=trajectory,
+                                 structure=structure,
+                                 vibration_amplitude=vibration_amplitude)
+
+        states = _calculate_atom_states(structure=structure,
+                                        trajectory=diff_trajectory,
+                                        dist_close=dist_close)
+        events = _calculate_transition_events(atom_sites=states)
+
+        obj = cls(events=events, states=states, n_sites=len(structure))
+
+        obj._dist_close = dist_close  # type: ignore
+
+        return obj
+
+    @lru_cache
+    def matrix(self):
+        """Convert list of transition events to dense matrix.
+
+        Returns
+        -------
+        transitions_matrix : np.ndarray
+            Square matrix with number of each transitions
+        """
+        return _calculate_transitions_matrix(self.events, n_sites=self.n_sites)
+
+    @lru_cache
+    def states_next(self):
+        """Calculate atom transition states per time step by backward filling
+        `self.states`.
+
+        Returns
+        -------
+        np.ndarray
+            Output array with atom transition states. `states_next` contains
+            the index of the next site for every atom.
+        """
+        return bfill(self.states, fill_val=NOSITE, axis=0)
+
+    @lru_cache
+    def states_prev(self):
+        """Calculate atom transition states per time step by forward filling
+        `self.states`.
+
+        Returns
+        -------
+        np.ndarray
+            Output array with atom transition states. `states_prev` contains
+            the index of the previous site for every atom.
+        """
+        return ffill(self.states, fill_val=NOSITE, axis=0)
+
+    def occupancy(self):
+        """Calculate occupancy per site.
+
+        Returns
+        -------
+        occupancy : dict[int, int]
+            For each site, count for how many time steps it is occupied by an atom
+        """
+        return _calculate_occupancy(self.states)
+
+    def split(self, n_parts: int = 10, *, n_steps: int):
+        """Split data into equal parts in time for statistics.
+
+        Parameters
+        ----------
+        n_parts : int
+            Number of parts to split the data into
+
+        Returns
+        -------
+        parts : list[SitesData]
+            List with `Transitions` object for each part
+        """
+        split_states = np.split(self.states, n_parts)
+        split_events = _split_transitions_events(self.events, n_steps, n_parts)
+
+        kwargs_list = []
+
+        for states, events in zip(split_states, split_events):
+            kwargs_list.append({
+                'states': states,
+                'events': events,
+                'n_sites': self.n_sites,
+            })
+
+        return [self.__class__(**kwargs) for kwargs in kwargs_list]
+
+
+def _calculate_transition_events(*, atom_sites: np.ndarray) -> np.ndarray:
+    """Find transitions between sites.
+
+    Parameters
+    ----------
+    atom_sites : np.ndarray
+        Input array with atom sites
+
+    Returns
+    -------
+    events : np.ndarray
+        Output array with transition events.
+        Contains 5 columns: atom index, time start, time stop, site start, site stop
+    """
+    events = []
+
+    for atom_index, atom_site in enumerate(atom_sites.T):
+
+        # Indices when atom jumps to new or back to same site
+        i, = np.nonzero((atom_site != np.roll(atom_site, shift=1))
+                        & (atom_site >= 0))
+
+        # Log transition events
+        i_event = np.nonzero(atom_site[i] != np.roll(atom_site[i], shift=-1))
+        time_start = i[i_event]
+        time_stop = np.roll(i, shift=-1)[i_event]
+        transitions = np.vstack([
+            np.ones_like(time_start) * atom_index,
+            atom_site[time_start],
+            atom_site[time_stop],
+            time_start,
+            time_stop,
+        ]).T
+
+        # Drop last event (side effect of np.roll)
+        transitions = transitions[:-1]
+        events.append(transitions)
+
+    return np.vstack(events)
+
+
+def _dist_close(trajectory: Trajectory, structure: Structure,
+                vibration_amplitude: float) -> float:
+    """Calculate tolerance wihin which atoms are considered to be close to a
+    site.
+
+    Parameters
+    ----------
+    trajectory : Trajectory
+        Input trajectory
+    structure : Structure
+        Input structure
+
+    Returns
+    -------
+    dist_close : float
+        Atoms within this distance (in Angstrom) are considered to be close to a site
+    """
+    lattice = trajectory.get_lattice()
+    dist_close = 2 * vibration_amplitude
+
+    site_coords = structure.frac_coords
+
+    pdist = lattice.get_all_distances(site_coords, site_coords)
+    min_dist = np.min(pdist[np.triu_indices_from(pdist, k=1)])
+
+    if min_dist < 2 * dist_close:
+        # Crystallographic sites are overlapping with the chosen dist_close, making it smaller
+        dist_close = (0.5 * min_dist) - 0.005
+
+        # Two crystallographic sites are within half an Angstrom of each other
+        # This is NOT realistic, check/change the given crystallographic site
+        if dist_close * 2 < 0.5:
+            idx = np.argwhere(pdist == min_dist)
+
+            lines = []
+
+            for i, j in idx:
+                structure.sites[i]
+                site_j = structure.sites[j]
+                lines.append('\nToo close:')
+                lines.append(
+                    '{site_i.specie.name}({i}) {site_i.frac_coords} - ')
+                lines.append(f'{site_j.specie.name}({j}) {site_j.frac_coords}')
+
+            msg = ''.join(lines)
+
+            raise ValueError(
+                f'Crystallographic sites are too close together (expected: >{dist_close*2:.4f}, '
+                f'got: {min_dist:.4f} for {msg}')
+
+    return dist_close
+
+
+def _calculate_atom_states(
+    structure: Structure,
+    trajectory: Trajectory,
+    dist_close: float,
+) -> np.ndarray:
+    """Calculate nearest site for each atom coordinate in the trajectory.
+
+    Note: This is a slow operation, because a pairwise distance matrix between all `coords` and
+    all `site_coords` has to be generated. This includes lattice translations. The nearest site
+    may be in the neighbouring unit cell.
+
+    Parameters
+    ----------
+    structure : Structure
+        Input structure with pre-defined sites
+    trajectory : Trajectory
+        Input trajectory for floating atoms
+    dist_close : float
+        Atoms within this distance (in Angstrom) are considered to be close to a site
+
+    Returns
+    -------
+    _calculate_atom_states : np.ndarray
+        Output array with site locations for each atom at each time step [time, atom].
+        The value corresponds to the index in the `site_coords`.
+        -1 indicates that atom is not at any site.
+    """
+    # Unit cell parameters
+    lattice = trajectory.get_lattice()
+
+    site_coords = structure.frac_coords
+
+    # Input array with site coordinates [site, (x, y, z)]
+    site_cart_coords = np.dot(site_coords, lattice.matrix)
+    site_coords_tree: PeriodicKDTree = PeriodicKDTree(
+        box=np.array(lattice.parameters, dtype=np.float32))
+    site_coords_tree.set_coords(site_cart_coords, cutoff=dist_close)
+
+    atom_sites = []
+
+    for atom_index, atom_coords in enumerate(
+            trajectory.positions.swapaxes(0, 1)):
+
+        # index and distance of nearest site
+        atom_cart_coords = np.dot(atom_coords, lattice.matrix)
+        site_index = site_coords_tree.search_tree(atom_cart_coords, dist_close)
+
+        # construct mapping
+        atom_site = np.full((atom_coords.shape[0], 1), NOSITE)
+        for index, site in site_index:
+            atom_site[index] = site
+
+        atom_sites.append(atom_site)
+
+    return np.hstack(atom_sites)
+
+
+def _calculate_transitions_matrix(events: np.ndarray,
+                                  n_sites: int) -> np.ndarray:
+    """Convert list of transition events to dense transitions matrix.
+
+    Parameters
+    ----------
+    events : np.ndarray
+        Input array with transition events
+    n_sites : int
+        Number of jump sites for diffusing element. This defines the shape of the output matrix.
+
+    Returns
+    -------
+    np.ndarray
+        Square matrix with number of each transitions
+    """
+    start_col = 1  # transition starts
+    stop_col = 2  # transition stop
+
+    transitions = np.zeros((n_sites, n_sites), dtype=int)
+    idx, counts = np.unique(events[:, [start_col, stop_col]],
+                            return_counts=True,
+                            axis=0)
+    start_idx, stop_idx = idx.T
+    transitions[start_idx, stop_idx] = counts
+    return transitions
+
+
+def _split_transitions_events(events: np.ndarray,
+                              n_steps: int,
+                              n_parts=10) -> list[np.ndarray]:
+    """Split list of transition events into equal parts in time.
+
+    Parameters
+    ----------
+    events : np.ndarray
+        Input array with transition events
+    n_steps : int
+        Number of time steps
+    n_parts : int, optional
+        Number of parts to split into
+
+    Returns
+    -------
+    transitions_parts : np.ndarray
+        Sorted list of transition events split into equal parts.
+        The first dimension corresponds to `n_parts`.
+    """
+    col = 4
+
+    bins = np.linspace(0, n_steps + 1, n_parts + 1, dtype=int)
+    parts = np.digitize(events[:, col], bins=bins)
+    parts = parts[parts.argsort()]
+    splits = np.unique(parts, return_index=True)[1][1:]
+
+    sorted_transitions = events[events[:, col].argsort()]
+
+    parts = np.split(sorted_transitions, splits)
+
+    if len(parts) < n_parts:
+        raise ValueError(
+            f'Not enough transitions per part to split into {n_parts}')
+
+    return parts
+
+
+def _calculate_occupancy(atom_sites: np.ndarray) -> dict[int, int]:
+    """Calculate occupancy per site.
+
+    Parameters
+    ----------
+    atom_sites : np.ndarray
+        Input array with atom sites
+
+    Returns
+    -------
+    occupancy : dict[int, int]
+        For each site, count for how many time steps it is occupied by an atom
+    """
+    unq, counts = np.unique(atom_sites, return_counts=True)
+    occupancy = dict(zip(unq, counts))
+    occupancy.pop(NOSITE, None)
+    return occupancy

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -32,11 +32,7 @@ def structure():
 
 @pytest.fixture(scope='module')
 def vasp_sites(vasp_traj, structure):
-    sites = SitesData(structure)
-    sites.calculate_all(trajectory=vasp_traj,
-                        diffusing_element='Li',
-                        z_ion=1,
-                        diffusion_dimensions=3,
-                        n_parts=10)
-
+    sites = SitesData(structure=structure,
+                      trajectory=vasp_traj,
+                      floating_specie='Li')
     return sites

--- a/tests/integration/rdf_test.py
+++ b/tests/integration/rdf_test.py
@@ -8,14 +8,9 @@ def test_rdf(vasp_traj, structure):
     # Shorten trajectory for faster test
     trajectory = vasp_traj[-1000:]
 
-    sites = SitesData(structure)
-    sites.calculate_all(
-        trajectory=trajectory,
-        diffusing_element='Li',
-        z_ion=1,
-        diffusion_dimensions=3,
-        n_parts=1,
-    )
+    sites = SitesData(structure=structure,
+                      trajectory=trajectory,
+                      floating_specie='Li')
 
     rdfs = calculate_rdfs(
         trajectory=trajectory,

--- a/tests/integration/sites_test.py
+++ b/tests/integration/sites_test.py
@@ -19,17 +19,22 @@ class TestSites:
         n_steps = len(vasp_traj)
         n_diffusing = vasp_sites.n_floating
 
-        assert vasp_sites.atom_sites().shape == (n_steps, n_diffusing)
-        assert vasp_sites.atom_sites().sum() == 6154859
-        assert vasp_sites.atom_sites_to().shape == (n_steps, n_diffusing)
-        assert vasp_sites.atom_sites_to().sum() == 8172006
-        assert vasp_sites.atom_sites_from().shape == (n_steps, n_diffusing)
-        assert vasp_sites.atom_sites_from().sum() == 8148552
+        transitions = vasp_sites.transitions
+
+        assert transitions._dist_close == 0.9284961123176741
+
+        assert transitions.states.shape == (n_steps, n_diffusing)
+        assert transitions.states.sum() == 6154859
+        assert transitions.states_next().shape == (n_steps, n_diffusing)
+        assert transitions.states_next().sum() == 8172006
+        assert transitions.states_prev().shape == (n_steps, n_diffusing)
+        assert transitions.states_prev().sum() == 8148552
 
     def test_all_transitions(self, vasp_sites):
-        assert vasp_sites.transition_events().shape == (450, 5)
-        assert vasp_sites.transitions_matrix().shape == (vasp_sites.n_sites,
-                                                         vasp_sites.n_sites)
+        transitions = vasp_sites.transitions
+        assert transitions.events.shape == (450, 5)
+        assert transitions.matrix().shape == (vasp_sites.n_sites,
+                                              vasp_sites.n_sites)
 
     def test_transitions_parts(self, vasp_sites):
         n_sites = vasp_sites.n_sites
@@ -39,8 +44,8 @@ class TestSites:
         assert np.sum(vasp_sites.transitions_parts[9]) == 38
 
     def test_occupancy(self, vasp_sites):
-        assert vasp_sites.occupancy()[0] == 1704
-        assert vasp_sites.occupancy()[43] == 542
+        assert vasp_sites.transitions.occupancy()[0] == 1704
+        assert vasp_sites.transitions.occupancy()[43] == 542
 
     def test_occupancy_parts(self, vasp_sites):
         assert len(vasp_sites.occupancy_parts) == self.n_parts

--- a/tests/integration/sites_test.py
+++ b/tests/integration/sites_test.py
@@ -17,20 +17,19 @@ class TestSites:
 
     def test_atom_sites(self, vasp_sites, vasp_traj):
         n_steps = len(vasp_traj)
-        n_diffusing = sum(
-            [sp.symbol == self.diffusing_element for sp in vasp_traj.species])
+        n_diffusing = vasp_sites.n_floating
 
-        assert vasp_sites.atom_sites.shape == (n_steps, n_diffusing)
-        assert vasp_sites.atom_sites.sum() == 6154859
-        assert vasp_sites.atom_sites_to.shape == (n_steps, n_diffusing)
-        assert vasp_sites.atom_sites_to.sum() == 8172006
-        assert vasp_sites.atom_sites_from.shape == (n_steps, n_diffusing)
-        assert vasp_sites.atom_sites_from.sum() == 8148552
+        assert vasp_sites.atom_sites().shape == (n_steps, n_diffusing)
+        assert vasp_sites.atom_sites().sum() == 6154859
+        assert vasp_sites.atom_sites_to().shape == (n_steps, n_diffusing)
+        assert vasp_sites.atom_sites_to().sum() == 8172006
+        assert vasp_sites.atom_sites_from().shape == (n_steps, n_diffusing)
+        assert vasp_sites.atom_sites_from().sum() == 8148552
 
     def test_all_transitions(self, vasp_sites):
-        assert vasp_sites.all_transitions.shape == (450, 5)
-        assert vasp_sites.transitions.shape == (vasp_sites.n_sites,
-                                                vasp_sites.n_sites)
+        assert vasp_sites.transition_events().shape == (450, 5)
+        assert vasp_sites.transitions_matrix().shape == (vasp_sites.n_sites,
+                                                         vasp_sites.n_sites)
 
     def test_transitions_parts(self, vasp_sites):
         n_sites = vasp_sites.n_sites
@@ -40,8 +39,8 @@ class TestSites:
         assert np.sum(vasp_sites.transitions_parts[9]) == 38
 
     def test_occupancy(self, vasp_sites):
-        assert vasp_sites.occupancy[0] == 1704
-        assert vasp_sites.occupancy[43] == 542
+        assert vasp_sites.occupancy()[0] == 1704
+        assert vasp_sites.occupancy()[43] == 542
 
     def test_occupancy_parts(self, vasp_sites):
         assert len(vasp_sites.occupancy_parts) == self.n_parts
@@ -51,22 +50,22 @@ class TestSites:
         assert vasp_sites.occupancy_parts[9][0] == 62
         assert vasp_sites.occupancy_parts[9][42] == 177
 
-    def test_sites_occupancy(self, vasp_sites):
-        assert isclose(vasp_sites.sites_occupancy['48h'],
+    def test_site_occupancy(self, vasp_sites):
+        assert isclose(vasp_sites.site_occupancy()['48h'],
                        0.380628,
                        rel_tol=1e-4)
 
-    def test_sites_occupancy_parts(self, vasp_sites):
-        assert len(vasp_sites.sites_occupancy_parts) == self.n_parts
-        assert isclose(vasp_sites.sites_occupancy_parts[0]['48h'],
+    def test_site_occupancy_parts(self, vasp_sites):
+        assert len(vasp_sites.site_occupancy_parts) == self.n_parts
+        assert isclose(vasp_sites.site_occupancy_parts[0]['48h'],
                        0.37756,
                        rel_tol=1e-4)
-        assert isclose(vasp_sites.sites_occupancy_parts[9]['48h'],
+        assert isclose(vasp_sites.site_occupancy_parts[9]['48h'],
                        0.36922,
                        rel_tol=1e-4)
 
     def test_atom_locations(self, vasp_sites):
-        assert isclose(vasp_sites.atom_locations['48h'],
+        assert isclose(vasp_sites.atom_locations()['48h'],
                        0.761255,
                        rel_tol=1e-4)
 
@@ -82,49 +81,52 @@ class TestSites:
     def test_n_jumps(self, vasp_sites):
         assert vasp_sites.n_solo_jumps == 1922
         assert vasp_sites.n_jumps == 450
-        assert isclose(vasp_sites.solo_frac, 4.2711, rel_tol=1e-4)
+        assert isclose(vasp_sites.solo_fraction, 4.2711, rel_tol=1e-4)
 
     def test_rates(self, vasp_sites):
-        assert isinstance(vasp_sites.rates, dict)
-        assert len(vasp_sites.rates) == 1
+        assert isinstance(vasp_sites.rates(), dict)
+        assert len(vasp_sites.rates()) == 1
 
-        rates, rates_std = vasp_sites.rates[('48h', '48h')]
+        rates, rates_std = vasp_sites.rates()[('48h', '48h')]
         assert isclose(rates, 1249999999999.9998)
         assert isclose(rates_std, 137337009020.29002)
 
     def test_activation_energies(self, vasp_sites):
-        assert isinstance(vasp_sites.activation_energies, dict)
-        assert len(vasp_sites.activation_energies) == 1
+        assert isinstance(vasp_sites.activation_energies(), dict)
+        assert len(vasp_sites.activation_energies()) == 1
 
-        e_act, e_act_std = vasp_sites.activation_energies[('48h', '48h')]
+        e_act, e_act_std = vasp_sites.activation_energies()[('48h', '48h')]
         assert isclose(e_act, 0.130754, rel_tol=1e-6)
         assert isclose(e_act_std, 0.0063201, rel_tol=1e-6)
 
     def test_jump_diffusivity(self, vasp_sites):
-        assert isclose(vasp_sites.jump_diffusivity,
+        assert isclose(vasp_sites.jump_diffusivity(3),
                        9.220713700212185e-09,
                        rel_tol=1e-6)
 
     def test_correlation_factor(self, vasp_sites):
-        assert isclose(vasp_sites.correlation_factor,
-                       0.1703355120150192,
-                       rel_tol=1e-6)
+        tracer_diff = vasp_sites.metrics.tracer_diffusivity(dimensions=3)
+        correlation_factor = tracer_diff / vasp_sites.jump_diffusivity(
+            dimensions=3)
+        assert isclose(correlation_factor, 0.1703355120150192, rel_tol=1e-6)
 
     def test_collective(self, vasp_sites):
-        assert vasp_sites.coll_count == 1280
-        assert len(vasp_sites.collective) == 1280
+        collective, coll_jumps, n_solo_jumps = vasp_sites.collective()
+        assert len(collective) == 1280
 
-        assert vasp_sites.collective[0] == (158, 384)
-        assert vasp_sites.collective[-1] == (348, 383)
+        assert collective[0] == (158, 384)
+        assert collective[-1] == (348, 383)
 
     def test_coll_jumps(self, vasp_sites):
-        assert len(vasp_sites.coll_jumps) == 1280
-        assert vasp_sites.coll_jumps[0] == ((74, 8), (41, 67))
-        assert vasp_sites.coll_jumps[-1] == ((15, 77), (21, 45))
+        collective, coll_jumps, n_solo_jumps = vasp_sites.collective()
 
-    def test_coll_matrix(self, vasp_sites):
-        assert vasp_sites.coll_matrix.shape == (1, 1)
-        assert vasp_sites.coll_matrix[0, 0] == 1280
+        assert len(coll_jumps) == 1280
+        assert coll_jumps[0] == ((74, 8), (41, 67))
+        assert coll_jumps[-1] == ((15, 77), (21, 45))
 
-    def test_multi_coll(self, vasp_sites):
-        assert vasp_sites.multi_coll.sum() == 434227
+    def test_collective_matrix(self, vasp_sites):
+        assert vasp_sites.collective_matrix().shape == (1, 1)
+        assert vasp_sites.collective_matrix()[0, 0] == 1280
+
+    def test_multiple_collective(self, vasp_sites):
+        assert vasp_sites.multiple_collective().sum() == 434227

--- a/tests/integration/sites_test.py
+++ b/tests/integration/sites_test.py
@@ -21,7 +21,7 @@ class TestSites:
 
         transitions = vasp_sites.transitions
 
-        assert isclose(transitions._dist_close, 0.928496)
+        assert isclose(transitions._dist_close, 0.9284961123176741)
 
         assert transitions.states.shape == (n_steps, n_diffusing)
         assert transitions.states.sum() == 6154859

--- a/tests/integration/sites_test.py
+++ b/tests/integration/sites_test.py
@@ -116,22 +116,24 @@ class TestSites:
         assert isclose(correlation_factor, 0.1703355120150192, rel_tol=1e-6)
 
     def test_collective(self, vasp_sites):
-        collective, coll_jumps, n_solo_jumps = vasp_sites.collective()
-        assert len(collective) == 1280
+        collective = vasp_sites.collective()
+        assert len(collective.collective) == 1280
 
-        assert collective[0] == (158, 384)
-        assert collective[-1] == (348, 383)
+        assert collective.collective[0] == (158, 384)
+        assert collective.collective[-1] == (348, 383)
 
     def test_coll_jumps(self, vasp_sites):
-        collective, coll_jumps, n_solo_jumps = vasp_sites.collective()
+        collective = vasp_sites.collective()
 
-        assert len(coll_jumps) == 1280
-        assert coll_jumps[0] == ((74, 8), (41, 67))
-        assert coll_jumps[-1] == ((15, 77), (21, 45))
+        assert len(collective.coll_jumps) == 1280
+        assert collective.coll_jumps[0] == ((74, 8), (41, 67))
+        assert collective.coll_jumps[-1] == ((15, 77), (21, 45))
 
     def test_collective_matrix(self, vasp_sites):
-        assert vasp_sites.collective_matrix().shape == (1, 1)
-        assert vasp_sites.collective_matrix()[0, 0] == 1280
+        collective = vasp_sites.collective()
+        assert collective.matrix().shape == (1, 1)
+        assert collective.matrix()[0, 0] == 1280
 
     def test_multiple_collective(self, vasp_sites):
-        assert vasp_sites.multiple_collective().sum() == 434227
+        collective = vasp_sites.collective()
+        assert collective.multiple_collective().sum() == 434227

--- a/tests/integration/sites_test.py
+++ b/tests/integration/sites_test.py
@@ -21,7 +21,7 @@ class TestSites:
 
         transitions = vasp_sites.transitions
 
-        assert transitions._dist_close == 0.9284961123176741
+        assert isclose(transitions._dist_close, 0.928496)
 
         assert transitions.states.shape == (n_steps, n_diffusing)
         assert transitions.states.sum() == 6154859

--- a/tests/integration/trajectory_test.py
+++ b/tests/integration/trajectory_test.py
@@ -43,12 +43,12 @@ def test_tracer(vasp_traj):
     assert isclose(metrics.particle_density(), 2.4557e28, rel_tol=1e-4)
     assert isclose(metrics.mol_per_liter(), 40.777, rel_tol=1e-4)
     assert isclose(
-        metrics.tracer_diffusivity(diffusion_dimensions=3),
+        metrics.tracer_diffusivity(dimensions=3),
         1.5706e-09,
         rel_tol=1e-4,
     )
     assert isclose(
-        metrics.tracer_conductivity(z_ion=1, diffusion_dimensions=3),
+        metrics.tracer_conductivity(z_ion=1, dimensions=3),
         110.322,
         rel_tol=1e-4,
     )

--- a/tests/simulation_metrics_test.py
+++ b/tests/simulation_metrics_test.py
@@ -8,11 +8,9 @@ def test_tracer_metrics(trajectory):
 
     assert (np.isclose(metrics.particle_density(), 1e30))
     assert (np.isclose(metrics.mol_per_liter(), 1660.53906))
-    assert (np.isclose(metrics.tracer_diffusivity(diffusion_dimensions=3),
-                       2.666667e-10))
-    assert (np.isclose(
-        metrics.tracer_conductivity(z_ion=1, diffusion_dimensions=3),
-        4.081278e-09))
+    assert (np.isclose(metrics.tracer_diffusivity(dimensions=3), 2.666667e-10))
+    assert (np.isclose(metrics.tracer_conductivity(z_ion=1, dimensions=3),
+                       4.081278e-09))
 
 
 def test_vibration_metrics(trajectory):

--- a/tests/sites_test.py
+++ b/tests/sites_test.py
@@ -1,5 +1,5 @@
 import numpy as np
-from gemdat.sites import _calculate_transitions_matrix
+from gemdat.transitions import _calculate_transitions_matrix
 
 
 def test_transitions_matrix():


### PR DESCRIPTION
This PR refactors all sites methods into property functions which can be calculated on demand, taking the work from #94 as a starting point.

I got into trouble with the $_parts functions, which did not refactor well. I made a new class called `Transitions`, which stores all the transition data that are the basis for the _parts attributes.

I also moved all code to calculate collections into its own class for better separation, and to make it a bit more ergonomic to work with the data.

### Todo

- [x] Can we make `SitesData.collective()` a bit more ergonomic? It currently returns 3 values
- [x] Add docstrings for methods on `Transitions`