### PR TITLE
Derive sites from trajectory (or other) density

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,12 +32,13 @@ classifiers = [
     "Topic :: Scientific/Engineering",
 ]
 dependencies = [
-  'pymatgen >= 2023.8.10',
-  'numpy',
-  'rich',
-  'scipy',
-  'matplotlib >= 3.6.0', # Axes3D.set_aspect('equal') introduced here
+  'matplotlib >= 3.6.0',
   'MDAnalysis',
+  'numpy',
+  'pymatgen >= 2023.8.10',
+  'rich',
+  'scikit-image',
+  'scipy',
 ]
 
 [project.urls]

--- a/src/volume.py
+++ b/src/volume.py
@@ -10,9 +10,10 @@ if TYPE_CHECKING:
     from pymatgen.core import Structure
 
 
-def trajectory_to_volume(trajectory: Trajectory,
-                         resolution: float = 0.2,
-                         cartesian: bool = False) -> np.ndarray:
+def trajectory_to_volume(
+    trajectory: Trajectory,
+    resolution: float = 0.2,
+) -> np.ndarray:
     """Calculate density volume from list of coordinates.
 
     Parameters
@@ -21,9 +22,6 @@ def trajectory_to_volume(trajectory: Trajectory,
         Input trajectory
     resolution : float, optional
         Minimum resolution for the voxels in Angstrom
-    cartesian : bool, optional
-        If True, return volume on a cartesian grid.
-        Useful for generic 3D volume viewers
 
     Returns
     -------
@@ -38,22 +36,12 @@ def trajectory_to_volume(trajectory: Trajectory,
     assert coords.min() >= 0
     assert coords.max() < 1
 
-    if cartesian:
-        coords = lattice.get_cartesian_coords(coords)
+    x0 = y0 = z0 = 0
+    x1 = y1 = z1 = 1
 
-        x0, y0, z0 = coords.min(axis=0)
-        x1, y1, z1 = coords.max(axis=0)
-
-        nx = int(1 + (x1 - x0) // resolution)
-        ny = int(1 + (y1 - y0) // resolution)
-        nz = int(1 + (z1 - z0) // resolution)
-    else:
-        x0 = y0 = z0 = 0
-        x1 = y1 = z1 = 1
-
-        nx = int(1 + lattice.lengths[0] // resolution)
-        ny = int(1 + lattice.lengths[1] // resolution)
-        nz = int(1 + lattice.lengths[2] // resolution)
+    nx = int(1 + lattice.lengths[0] // resolution)
+    ny = int(1 + lattice.lengths[1] // resolution)
+    nz = int(1 + lattice.lengths[2] // resolution)
 
     # Drop first item, because bins are open-ended on left side
     xbins = np.linspace(x0, x1, nx)[1:]
@@ -110,3 +98,10 @@ def trajectory_to_vasp_volume(trajectory: Trajectory,
         vasp_vol.write_file(filename)
 
     return vasp_vol
+
+
+def volume_to_structure(vol: VolumetricData | np.ndarray) -> Structure:
+    if isinstance(vol, VolumetricData):
+        vol = vol.data['total']
+
+    pass

--- a/src/volume.py
+++ b/src/volume.py
@@ -34,6 +34,10 @@ def trajectory_to_volume(trajectory: Trajectory,
 
     coords = trajectory.positions.reshape(-1, 3)
 
+    # coords must be between >= 0, < 1
+    assert coords.min() >= 0
+    assert coords.max() < 1
+
     if cartesian:
         coords = lattice.get_cartesian_coords(coords)
 
@@ -51,9 +55,10 @@ def trajectory_to_volume(trajectory: Trajectory,
         ny = int(1 + lattice.lengths[1] // resolution)
         nz = int(1 + lattice.lengths[2] // resolution)
 
-    xbins = np.linspace(x0, x1, nx)
-    ybins = np.linspace(y0, y1, ny)
-    zbins = np.linspace(z0, z1, nz)
+    # Drop first item, because bins are open-ended on left side
+    xbins = np.linspace(x0, x1, nx)[1:]
+    ybins = np.linspace(y0, y1, ny)[1:]
+    zbins = np.linspace(z0, z1, nz)[1:]
 
     digitized_coords = np.vstack([
         np.digitize(coords[:, 0], bins=xbins),
@@ -64,7 +69,7 @@ def trajectory_to_volume(trajectory: Trajectory,
     indices, counts = np.unique(digitized_coords, return_counts=True, axis=0)
     i, j, k = indices.T
 
-    vol = np.zeros((nx + 1, ny + 1, nz + 1), dtype=int)
+    vol = np.zeros((nx - 1, ny - 1, nz - 1), dtype=int)
     vol[i, j, k] = counts
 
     return vol

--- a/src/volume.py
+++ b/src/volume.py
@@ -180,6 +180,9 @@ def volume_to_structure(
     # Move coords to voxel center by shifting 0.5
     frac_coords = (centroids + 0.5) / np.array(vol.shape)
 
+    # mod to unit cell
+    frac_coords = np.mod(frac_coords, 1)
+
     structure = Structure(lattice=lattice,
                           coords=frac_coords,
                           species=[specie for _ in frac_coords])

--- a/tests/integration/trajectory_test.py
+++ b/tests/integration/trajectory_test.py
@@ -3,20 +3,26 @@ from math import isclose
 import numpy as np
 import pytest
 from gemdat.simulation_metrics import SimulationMetrics
-from gemdat.volume import trajectory_to_volume
+from gemdat.volume import trajectory_to_volume, volume_to_structure
+from pymatgen.core import Structure
+
+
+@pytest.fixture
+def vasp_vol(vasp_traj):
+    trajectory = vasp_traj
+    diff_trajectory = trajectory.filter('Li')
+    return trajectory_to_volume(trajectory=diff_trajectory, resolution=0.2)
 
 
 @pytest.vaspxml_available
-def test_volume(vasp_traj):
-    trajectory = vasp_traj
+def test_volume(vasp_vol, vasp_traj):
+    vol = vasp_vol
 
-    diff_trajectory = trajectory.filter('Li')
-
-    vol = trajectory_to_volume(trajectory=diff_trajectory, resolution=0.2)
+    n_species = sum(sp.symbol == 'Li' for sp in vasp_traj.species)
 
     assert isinstance(vol, np.ndarray)
     assert vol.shape == (99, 49, 49)
-    assert vol.sum() == len(diff_trajectory.species) * len(diff_trajectory)
+    assert vol.sum() == n_species * len(vasp_traj)
 
     # make sure edges are not empty
     s_ = np.s_
@@ -24,9 +30,19 @@ def test_volume(vasp_traj):
         assert vol[s].sum() != 0
 
 
+def test_volume_to_structure(vasp_traj, vasp_vol):
+    structure = volume_to_structure(vasp_vol,
+                                    lattice=vasp_traj.get_lattice(),
+                                    specie='Li')
+
+    assert isinstance(structure, Structure)
+    assert len(structure) == 190
+    assert np.min(structure.frac_coords) >= 0
+    assert np.max(structure.frac_coords) < 1
+
+
 @pytest.vaspxml_available
 def test_tracer(vasp_traj):
-
     diff_trajectory = vasp_traj.filter('Li')
     metrics = SimulationMetrics(diff_trajectory)
 

--- a/tests/integration/trajectory_test.py
+++ b/tests/integration/trajectory_test.py
@@ -15,23 +15,13 @@ def test_volume(vasp_traj):
     vol = trajectory_to_volume(trajectory=diff_trajectory, resolution=0.2)
 
     assert isinstance(vol, np.ndarray)
-    assert vol.shape == (101, 51, 51)
+    assert vol.shape == (99, 49, 49)
     assert vol.sum() == len(diff_trajectory.species) * len(diff_trajectory)
 
-
-@pytest.vaspxml_available
-def test_volume_cartesian(vasp_traj):
-    trajectory = vasp_traj
-
-    diff_trajectory = trajectory.filter('Li')
-
-    vol = trajectory_to_volume(trajectory=diff_trajectory,
-                               resolution=0.2,
-                               cartesian=True)
-
-    assert isinstance(vol, np.ndarray)
-    assert vol.shape == (101, 51, 52)
-    assert vol.sum() == len(diff_trajectory.species) * len(diff_trajectory)
+    # make sure edges are not empty
+    s_ = np.s_
+    for s in s_[0], s_[:, 0], s_[:, :, 0], s_[-1], s_[:, -1], s_[:, :, -1]:
+        assert vol[s].sum() != 0
 
 
 @pytest.vaspxml_available


### PR DESCRIPTION
This PR adds a new function `volume.volume_to_structure` that takes a volume, finds the peaks using image segmentation, and returns a `Structure` object.

```python
from gemdat import Trajectory
from gemdat.volume import trajectory_to_volume
from gemdat.volume import volume_to_structure

trajectory = Trajectory.from_vasprun('/home/stef/md-analysis-matlab-example/vasprun.xml')
trajectory = trajectory.filter('Li')

vol = trajectory_to_volume(trajectory)

structure = volume_to_structure(
    vol, 
    lattice=trajectory.get_lattice(), 
    specie='Li',
    cif_filename='structure.cif',
    vol_filename='structure.vol',
)
```

Closes #45

### Todo

- [x] Tests
- [x] Update documentation
- [x] Handle densities at the edge of the volume (these result in split sites)