### PR TITLE
Refactor `Volume.to_structure` and revert to padded watershed for pbc

### DIFF
--- a/tests/integration/trajectory_test.py
+++ b/tests/integration/trajectory_test.py
@@ -14,7 +14,7 @@ def vasp_vol(vasp_traj):
     return trajectory_to_volume(trajectory=diff_trajectory, resolution=0.2)
 
 
-@pytest.vaspxml_available  # type: ignore
+@pytest.vaspxml_available
 def test_volume(vasp_vol, vasp_traj):
     data = vasp_vol.data
 
@@ -30,9 +30,10 @@ def test_volume(vasp_vol, vasp_traj):
         assert data[s].sum() != 0
 
 
-@pytest.mark.skip(reason='https://github.com/GEMDAT-repos/GEMDAT/issues/138')
-def test_volume_to_structure(vasp_vol):
-    structure = vasp_vol.to_structure(specie='Li', pad=5)
+# @pytest.mark.skip(reason='https://github.com/GEMDAT-repos/GEMDAT/issues/138')
+@pytest.vaspxml_available
+def test_volume_to_structure_centroid(vasp_vol):
+    structure = vasp_vol.to_structure(specie='Li', pad=5, method='centroid')
 
     assert isinstance(structure, Structure)
     assert len(structure) == 157
@@ -41,8 +42,9 @@ def test_volume_to_structure(vasp_vol):
     assert all(sp.symbol == 'Li' for sp in structure.species)
 
 
-def test_volume_to_structure2(vasp_vol):
-    structure = vasp_vol.to_structure2(specie='Li', pad=5)
+@pytest.vaspxml_available
+def test_volume_to_structure_cluster(vasp_vol):
+    structure = vasp_vol.to_structure(specie='Li', pad=5, method='cluster')
 
     assert hasattr(vasp_vol, 'positions')
     assert hasattr(vasp_vol, 'voxel_mapping')
@@ -54,7 +56,7 @@ def test_volume_to_structure2(vasp_vol):
     assert all(sp.symbol == 'Li' for sp in structure.species)
 
 
-@pytest.vaspxml_available  # type: ignore
+@pytest.vaspxml_available
 def test_tracer(vasp_traj):
     diff_trajectory = vasp_traj.filter('Li')
     metrics = SimulationMetrics(diff_trajectory)
@@ -73,7 +75,7 @@ def test_tracer(vasp_traj):
     )
 
 
-@pytest.vaspxml_available  # type: ignore
+@pytest.vaspxml_available
 def test_vibration_metrics(vasp_traj):
     diff_trajectory = vasp_traj.filter('Li')
     metrics = SimulationMetrics(diff_trajectory)

--- a/tests/segmentation_test.py
+++ b/tests/segmentation_test.py
@@ -1,8 +1,10 @@
 import numpy as np
+import pytest
 from gemdat.segmentation import watershed_pbc
 
 
 def test_watershed06():
+    """Test watershed in horizontal direction."""
     data = np.array(
         [
             [1, 1, 1, 1, 1, 1, 1],
@@ -35,6 +37,42 @@ def test_watershed06():
         [1, 1, 1, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0, 0, 0],
+    ])
+
+    np.testing.assert_allclose(out, expected)
+
+
+@pytest.mark.xfail(reason='https://github.com/GEMDAT-repos/GEMDAT/issues/138')
+def test_watershed07():
+    """Test watershed in vertical direction."""
+    data = np.array(
+        [
+            [1, 1, 0, 0, 0, 0, 0, 1, 1],
+            [1, 1, 0, 0, 0, 0, 0, 1, 1],
+            [1, 1, 0, 0, 0, 0, 0, 1, 1],
+            [1, 1, 1, 1, 1, 1, 1, 1, 1],
+            [1, 1, 1, 1, 1, 1, 1, 1, 1],
+            [1, 0, 0, 0, 0, 0, 1, 1, 1],
+            [1, 0, 0, 0, 0, 0, 1, 1, 1],
+        ],
+        dtype=int,
+    )
+
+    mask = data == 0
+
+    markers = np.zeros_like(data, dtype=int)
+    markers[6, 4] = 1
+
+    out = watershed_pbc(data, markers, mask=mask)
+
+    expected = np.array([
+        [0, 0, 1, 1, 1, 1, 1, 0, 0],
+        [0, 0, 1, 1, 1, 1, 1, 0, 0],
+        [0, 0, 1, 1, 1, 1, 1, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 1, 1, 1, 1, 1, 0, 0, 0],
+        [0, 1, 1, 1, 1, 1, 0, 0, 0],
     ])
 
     np.testing.assert_allclose(out, expected)

--- a/tests/segmentation_test.py
+++ b/tests/segmentation_test.py
@@ -1,9 +1,8 @@
 import numpy as np
-import pytest
 from gemdat.segmentation import watershed_pbc
 
 
-def test_watershed06():
+def test_watershed_horizontal():
     """Test watershed in horizontal direction."""
     data = np.array(
         [
@@ -25,7 +24,11 @@ def test_watershed06():
     markers = np.zeros_like(data, dtype=int)
     markers[4, 0] = 1
 
-    out = watershed_pbc(data, markers, mask=mask)
+    out = watershed_pbc(
+        data,
+        markers,
+        mask=mask,
+    )
 
     expected = np.array([
         [0, 0, 0, 0, 0, 0, 0],
@@ -42,8 +45,7 @@ def test_watershed06():
     np.testing.assert_allclose(out, expected)
 
 
-@pytest.mark.xfail(reason='https://github.com/GEMDAT-repos/GEMDAT/issues/138')
-def test_watershed07():
+def test_watershed_vertical():
     """Test watershed in vertical direction."""
     data = np.array(
         [


### PR DESCRIPTION
I'm investigating what is the cause for #138. I refactored the two `Volume.to_structure()` methods to share code. I added a failing test for what I think is the cause of the problem:

The watershed implementation works with flattened arrays, which means you get 'free' wrapping around in the horizontal directions, although not quite, because by wrapping around it would shift one row up or down. Once you reach there end of the flattened array, this falls appart, because once you hit the last rows, the connectivity structure potentially hits unbound memory (The function has `@cython.boundscheck(False)`).

---

I reverted part of #130 that changed the watershed implementation to deal with pbc. Now it uses padding again, this is a bit less memory efficient, but it works and passes the tests without crashing.

Closes #138 