### PR TITLE
Added descriptive error on loading incomplete xml file, append kwargs to cache path

### DIFF
--- a/src/gemdat/trajectory.py
+++ b/src/gemdat/trajectory.py
@@ -4,6 +4,7 @@ dynamics simulations."""
 from __future__ import annotations
 
 import pickle
+import xml.etree.ElementTree as ET
 from itertools import compress
 from pathlib import Path
 from typing import Collection, Optional
@@ -180,7 +181,7 @@ class Trajectory(PymatgenTrajectory):
         kwargs.setdefault('parse_potcar_file', False)
 
         if not cache:
-            cache = Path(str(xml_file) + '.cache')
+            cache = Path(str(xml_file) + '.' + str(kwargs) + '.cache')
 
         if Path(cache).exists():
             try:
@@ -188,8 +189,13 @@ class Trajectory(PymatgenTrajectory):
             except Exception as e:
                 print(e)
                 print('Error reading from cache, reading full VaspRun')
-
-        run = vasp.Vasprun(xml_file, **kwargs)
+        try:
+            run = vasp.Vasprun(xml_file, **kwargs)
+        except ET.ParseError as e:
+            raise Exception(
+                'Error parsing the vasprun.xml, to parse incomplete data'
+                " adding 'exception_on_bad_xml=False' to"
+                ' Trajectory.from_vasprun function might help') from e
 
         metadata = {'temperature': run.parameters['TEBEG']}
 

--- a/src/gemdat/trajectory.py
+++ b/src/gemdat/trajectory.py
@@ -181,7 +181,9 @@ class Trajectory(PymatgenTrajectory):
         kwargs.setdefault('parse_potcar_file', False)
 
         if not cache:
-            cache = Path(str(xml_file) + '.' + str(kwargs) + '.cache')
+            cache = Path(
+                str(xml_file) + '.' + str(hash(repr(sorted(kwargs.items())))) +
+                '.cache')
 
         if Path(cache).exists():
             try:


### PR DESCRIPTION
This PR does two things:
- It might happen that runs are incomplete, if this happens add a helpful message for hinting that this might be the case, and how to resolve it #157 
- Append the kwargs to the cache path, because using different kwargs will result in different caches, this links to issue #158 
  - Issue: this leads to very long filenames, it might be possible to store this info _inside_ the cache instead, so this comparison can still be done, and the cache can be refreshed on keyword changes.  however this would require some thought, and this solution is much simpler