### PR TITLE
Allow uneven splits with np.array_split

### DIFF
--- a/src/gemdat/simulation_metrics.py
+++ b/src/gemdat/simulation_metrics.py
@@ -182,7 +182,7 @@ class SimulationMetrics:
             # get indices where sign flips
             splits = np.where(signs != np.roll(signs, shift=-1))[0]
             # strip first and last splits
-            subarrays = np.split(speed_range, splits[1:-1] + 1)
+            subarrays = np.array_split(speed_range, splits[1:-1] + 1)
 
             amplitudes.extend([np.sum(array) for array in subarrays])
 

--- a/src/gemdat/transitions.py
+++ b/src/gemdat/transitions.py
@@ -149,7 +149,7 @@ class Transitions:
         parts : list[SitesData]
             List with `Transitions` object for each part
         """
-        split_states = np.split(self.states, n_parts)
+        split_states = np.array_split(self.states, n_parts)
         split_events = _split_transitions_events(self.events, n_steps, n_parts)
 
         kwargs_list = []
@@ -375,7 +375,7 @@ def _split_transitions_events(events: np.ndarray,
 
     sorted_transitions = events[events[:, col].argsort()]
 
-    parts = np.split(sorted_transitions, splits)
+    parts = np.array_split(sorted_transitions, splits)
 
     if len(parts) < n_parts:
         raise ValueError(


### PR DESCRIPTION
Sometimes nparts does not evenly divide an array, but for us this is okay, we can work with uneven arrays. Therefore we replace np.split with np.array_split