### PR TITLE
Make sure the aspect ratio of the density plot is similar to the volume

### DIFF
--- a/src/gemdat/plots/_density.py
+++ b/src/gemdat/plots/_density.py
@@ -190,9 +190,9 @@ def density(vol: Volume, structure: Optional[Structure] = None) -> go.Figure:
                       scene={
                           'aspectmode': 'manual',
                           'aspectratio': {
-                              'x': structure.lattice.a,
-                              'y': structure.lattice.b,
-                              'z': structure.lattice.c,
+                              'x': vol.lattice.a,
+                              'y': vol.lattice.b,
+                              'z': vol.lattice.c,
                           },
                           'xaxis_title': 'X (Ångstrom)',
                           'yaxis_title': 'Y (Ångstrom)',
@@ -213,20 +213,10 @@ def density(vol: Volume, structure: Optional[Structure] = None) -> go.Figure:
                           't': 0
                       },
                       scene_camera={
-                          'up': {
-                              'x': 0,
-                              'y': 0,
-                              'z': 1
-                          },
-                          'center': {
-                              'x': 0,
-                              'y': 0,
-                              'z': 0
-                          },
                           'eye': {
-                              'x': -structure.lattice.a * 0.5,
-                              'y': -structure.lattice.b * 2,
-                              'z': structure.lattice.c * 1.5,
+                              'x': -vol.lattice.a * 0.5,
+                              'y': -vol.lattice.b * 2,
+                              'z': vol.lattice.c * 1.5,
                           }
                       })
 

--- a/src/gemdat/plots/_density.py
+++ b/src/gemdat/plots/_density.py
@@ -182,14 +182,13 @@ def density(vol: Volume, structure: Structure) -> go.Figure:
     plot_lattice_vectors(lattice, fig=fig)
     plot_points(structure.cart_coords, structure.labels, fig=fig)
     plot_volume(vol, fig=fig)
-
     fig.update_layout(title='Density',
                       scene={
                           'aspectmode': 'manual',
                           'aspectratio': {
-                              'x': 2,
-                              'y': 1,
-                              'z': 1
+                              'x': structure.lattice.a,
+                              'y': structure.lattice.b,
+                              'z': structure.lattice.c,
                           },
                           'xaxis_title': 'X (Angstrom)',
                           'yaxis_title': 'Y (Angstrom)',
@@ -221,9 +220,9 @@ def density(vol: Volume, structure: Structure) -> go.Figure:
                               'z': 0
                           },
                           'eye': {
-                              'x': -1,
-                              'y': 1,
-                              'z': -0.6
+                              'x': -structure.lattice.a * 0.5,
+                              'y': -structure.lattice.b * 2,
+                              'z': structure.lattice.c * 1.5,
                           }
                       })
 


### PR DESCRIPTION
I noticed it was hardcoded to 2,1,1 . So I changed it to `lattice.abc` also adjusted the "eye" location to provide a view relative to `lattice.abc` instead of 2,1,1