### PR TITLE
Return structure with occupancy set as Composition

### DIFF
--- a/src/gemdat/jumps.py
+++ b/src/gemdat/jumps.py
@@ -249,7 +249,7 @@ class Jumps:
             self.sites.atom_locations(part)
             for part in self.transitions.split(n_parts)
         ]
-        parts = [part.jumps_counter() for part in self.split(n_parts)]
+        jumps_counter_parts = [part.jumps_counter() for part in self.split(n_parts)]
 
         for site_pair in self.sites.site_pairs:
             site_start, site_stop = site_pair

--- a/src/gemdat/jumps.py
+++ b/src/gemdat/jumps.py
@@ -227,13 +227,15 @@ class Jumps:
 
     @weak_lru_cache()
     def activation_energies(
-            self) -> dict[tuple[str, str], tuple[float, float]]:
+            self, n_parts: int) -> dict[tuple[str, str], tuple[float, float]]:
         """Calculate activation energies for jumps (UNITS?).
 
         Returns
         -------
         e_act : dict[tuple[str, str], tuple[float, float]]
             Dictionary with jump activation energies and standard deviations between site pairs.
+        n_parts : int
+            Number of parts to split transitions into for statistics
         """
         trajectory = self.transitions.trajectory
         attempt_freq, _ = SimulationMetrics(trajectory).attempt_frequency()
@@ -242,16 +244,18 @@ class Jumps:
 
         temperature = trajectory.metadata['temperature']
 
-        atom_locations_parts = self.sites.atom_locations_parts(
-            self.transitions)
-        parts = self.jumps_counter_parts(self.sites.n_parts)
+        atom_locations_parts = [
+            self.sites.atom_locations(part)
+            for part in self.transitions.split(n_parts)
+        ]
+        parts = [part.jumps_counter() for part in self.split(n_parts)]
 
         for site_pair in self.sites.site_pairs:
             site_start, site_stop = site_pair
 
             n_jumps = np.array([part[site_pair] for part in parts])
 
-            part_time = trajectory.total_time / self.sites.n_parts
+            part_time = trajectory.total_time / n_parts
 
             atom_percentage = np.array(
                 [part[site_start] for part in atom_locations_parts])
@@ -300,28 +304,25 @@ class Jumps:
         ]
 
     @weak_lru_cache()
-    def jumps_counter_parts(self, n_parts) -> list[Counter]:
-        """Return [jump counters][gemdat.sites.SitesData.jumps] per part."""
-
-        return [part.jumps_counter() for part in self.split(n_parts)]
-
-    @weak_lru_cache()
-    def rates(self) -> dict[tuple[str, str], tuple[float, float]]:
+    def rates(self,
+              n_parts: int) -> dict[tuple[str, str], tuple[float, float]]:
         """Calculate jump rates (total jumps / second).
 
         Returns
         -------
         rates : dict[tuple[str, str], tuple[float, float]]
             Dictionary with jump rates and standard deviations between site pairs
+        n_parts : int
+            Number of parts to split transitions into for statistics
         """
         rates: dict[tuple[str, str], tuple[float, float]] = {}
 
-        parts = self.jumps_counter_parts(self.sites.n_parts)
+        parts = [part.jumps_counter() for part in self.split(n_parts)]
 
         for site_pair in self.sites.site_pairs:
             n_jumps = [part[site_pair] for part in parts]
 
-            part_time = self.transitions.trajectory.total_time / self.sites.n_parts
+            part_time = self.transitions.trajectory.total_time / n_parts
             denom = self.n_floating * part_time
 
             jump_freq_mean = np.mean(n_jumps) / denom

--- a/src/gemdat/jumps.py
+++ b/src/gemdat/jumps.py
@@ -249,12 +249,15 @@ class Jumps:
             self.sites.atom_locations(part)
             for part in self.transitions.split(n_parts)
         ]
-        jumps_counter_parts = [part.jumps_counter() for part in self.split(n_parts)]
+        jumps_counter_parts = [
+            part.jumps_counter() for part in self.split(n_parts)
+        ]
 
         for site_pair in self.sites.site_pairs:
             site_start, site_stop = site_pair
 
-            n_jumps = np.array([part[site_pair] for part in jump_counter_parts])
+            n_jumps = np.array(
+                [part[site_pair] for part in jumps_counter_parts])
 
             part_time = trajectory.total_time / n_parts
 

--- a/src/gemdat/jumps.py
+++ b/src/gemdat/jumps.py
@@ -235,7 +235,7 @@ class Jumps:
         e_act : dict[tuple[str, str], tuple[float, float]]
             Dictionary with jump activation energies and standard deviations between site pairs.
         n_parts : int
-            Number of parts to split transitions into for statistics
+            Number of parts to split transitions/jumps into for statistics
         """
         trajectory = self.transitions.trajectory
         attempt_freq, _ = SimulationMetrics(trajectory).attempt_frequency()
@@ -313,7 +313,7 @@ class Jumps:
         rates : dict[tuple[str, str], tuple[float, float]]
             Dictionary with jump rates and standard deviations between site pairs
         n_parts : int
-            Number of parts to split transitions into for statistics
+            Number of parts to split jumps into for statistics
         """
         rates: dict[tuple[str, str], tuple[float, float]] = {}
 

--- a/src/gemdat/jumps.py
+++ b/src/gemdat/jumps.py
@@ -254,7 +254,7 @@ class Jumps:
         for site_pair in self.sites.site_pairs:
             site_start, site_stop = site_pair
 
-            n_jumps = np.array([part[site_pair] for part in parts])
+            n_jumps = np.array([part[site_pair] for part in jump_counter_parts])
 
             part_time = trajectory.total_time / n_parts
 

--- a/src/gemdat/jumps.py
+++ b/src/gemdat/jumps.py
@@ -227,7 +227,8 @@ class Jumps:
 
     @weak_lru_cache()
     def activation_energies(
-            self, n_parts: int) -> dict[tuple[str, str], tuple[float, float]]:
+            self,
+            n_parts: int = 10) -> dict[tuple[str, str], tuple[float, float]]:
         """Calculate activation energies for jumps (UNITS?).
 
         Returns
@@ -305,7 +306,7 @@ class Jumps:
 
     @weak_lru_cache()
     def rates(self,
-              n_parts: int) -> dict[tuple[str, str], tuple[float, float]]:
+              n_parts: int = 10) -> dict[tuple[str, str], tuple[float, float]]:
         """Calculate jump rates (total jumps / second).
 
         Returns

--- a/src/gemdat/legacy.py
+++ b/src/gemdat/legacy.py
@@ -92,7 +92,6 @@ def analyse_md(
         structure=sites_structure,
         trajectory=trajectory,
         floating_specie=diff_elem,
-        n_parts=nr_parts,
     )
 
     transitions = Transitions.from_trajectory(trajectory=trajectory,

--- a/src/gemdat/sites.py
+++ b/src/gemdat/sites.py
@@ -29,7 +29,6 @@ class SitesData:
         structure: Structure,
         trajectory: Trajectory,
         floating_specie: str,
-        n_parts: int = 10,
         site_radius: Optional[float] = None,
     ):
         """Contain sites and jumps data.
@@ -42,8 +41,6 @@ class SitesData:
             Input trajectory
         floating_specie : str
             Name of the floating or diffusing specie
-        n_parts : int, optional
-            Number of parts to divide transitions into for statistics
         site_radius: Optional[float]
             if set it fixes the site_radius instead of determining it
             dynamically
@@ -51,8 +48,6 @@ class SitesData:
         if not trajectory.constant_lattice:
             raise ValueError(
                 'Trajectory must have constant lattice for site analysis.')
-
-        self.n_parts = n_parts
 
         self.floating_specie = floating_specie
         self.structure = structure
@@ -100,12 +95,6 @@ class SitesData:
         labels = self.site_labels
         site_pairs = product(labels, repeat=2)
         return [pair for pair in site_pairs]  # type: ignore
-
-    def occupancy_parts(self,
-                        transitions: Transitions) -> list[dict[int, int]]:
-        """Return [occupancy arrays][gemdat.transitions.Transitions.occupancy]
-        from parts."""
-        return [part.occupancy() for part in transitions.split(self.n_parts)]
 
     def site_occupancy_parts(
             self, transitions: Transitions) -> list[dict[str, float]]:

--- a/src/gemdat/sites.py
+++ b/src/gemdat/sites.py
@@ -107,11 +107,11 @@ class SitesData:
         compositions_by_label = defaultdict(list)
 
         for site in transitions.occupancy():
-            compositions_by_label[site.label].append(site.composition)
+            compositions_by_label[site.label].append(site.species.num_atoms)
 
         ret = {}
 
         for k, v in compositions_by_label.items():
-            ret[k] = sum(v) * multiplier
+            ret[k] = (sum(v) / len(v)) * multiplier
 
         return ret

--- a/src/gemdat/sites.py
+++ b/src/gemdat/sites.py
@@ -9,14 +9,12 @@ from typing import Optional
 import numpy as np
 from pymatgen.core import Structure
 
-from .caching import weak_lru_cache
 from .simulation_metrics import SimulationMetrics
-from .transitions import Transitions
 from .utils import is_lattice_similar
 
 if typing.TYPE_CHECKING:
-
     from gemdat.trajectory import Trajectory
+    from gemdat.transitions import Transitions
 
 NOSITE = -1
 
@@ -96,48 +94,7 @@ class SitesData:
         site_pairs = product(labels, repeat=2)
         return [pair for pair in site_pairs]  # type: ignore
 
-    def site_occupancy_parts(
-            self, transitions: Transitions) -> list[dict[str, float]]:
-        """Return [site occupancy][gemdat.sites.SitesData.site_occupancy] dicts
-        per part."""
-        labels = self.site_labels
-        n_steps = len(self.trajectory)
-
-        parts = transitions.split(self.n_parts)
-
-        return [
-            _calculate_site_occupancy(occupancy=part.occupancy(),
-                                      labels=labels,
-                                      n_steps=int(n_steps / self.n_parts))
-            for part in parts
-        ]
-
-    @weak_lru_cache()
-    def atom_locations_parts(
-            self, transitions: Transitions) -> list[dict[str, float]]:
-        """Return [atom locations][gemdat.sites.SitesData.atom_locations] dicts
-        per part."""
-        multiplier = self.n_sites / self.n_floating
-        return [{
-            k: v * multiplier
-            for k, v in part.items()
-        } for part in self.site_occupancy_parts(transitions)]
-
-    def site_occupancy(self, transitions: Transitions):
-        """Calculate percentage occupancy per unique site.
-
-        Returns
-        -------
-        site_occopancy : dict[str, float]
-            Percentage occupancy per unique site
-        """
-        labels = self.site_labels
-        n_steps = len(self.trajectory)
-        return _calculate_site_occupancy(occupancy=transitions.occupancy(),
-                                         labels=labels,
-                                         n_steps=n_steps)
-
-    def atom_locations(self, transitions):
+    def atom_locations(self, transitions: Transitions):
         """Calculate fraction of time atoms spent at a type of site.
 
         Returns
@@ -146,45 +103,15 @@ class SitesData:
             Return dict with the fraction of time atoms spent at a site
         """
         multiplier = self.n_sites / self.n_floating
-        return {
-            k: v * multiplier
-            for k, v in self.site_occupancy(transitions).items()
-        }
 
+        compositions_by_label = defaultdict(list)
 
-def _calculate_site_occupancy(
-    *,
-    occupancy: dict[int, int],
-    labels: list[str],
-    n_steps: int,
-) -> dict[str, float]:
-    """Calculate percentage occupancy per unique site.
+        for site in transitions.occupancy():
+            compositions_by_label[site.label].append(site.composition)
 
-    Parameters
-    ----------
-    occupancy : dict[int, int]
-        Occupancy dict
-    labels : list[str]
-        Site labels
-    n_steps : int
-        Number of steps in time series
+        ret = {}
 
-    Returns
-    -------
-    dict[str, float]
-        Percentage occupancy per unique site
-    """
-    counts = defaultdict(list)
+        for k, v in compositions_by_label.items():
+            ret[k] = sum(v) * multiplier
 
-    assert all(v >= 0 for v in occupancy)
-
-    for k, v in occupancy.items():
-        label = labels[k]
-        counts[label].append(v)
-
-    site_occupancies = {
-        k: sum(v) / (n_steps * labels.count(k))
-        for k, v in counts.items()
-    }
-
-    return site_occupancies
+        return ret

--- a/src/gemdat/trajectory.py
+++ b/src/gemdat/trajectory.py
@@ -366,7 +366,7 @@ class Trajectory(PymatgenTrajectory):
                               time_step=self.time_step)
 
     def split(self,
-              n_parts: int,
+              n_parts: int = 10,
               equal_parts: bool = False) -> list[Trajectory]:
         """Split the trajectory in n similar parts.
 
@@ -381,7 +381,6 @@ class Trajectory(PymatgenTrajectory):
         -------
         List[Trajectory]
         """
-
         interval = np.linspace(0, len(self) - 1, n_parts + 1, dtype=int)
         subtrajectories = [
             self[start:stop] for start, stop in pairwise(interval)

--- a/src/gemdat/transitions.py
+++ b/src/gemdat/transitions.py
@@ -193,11 +193,6 @@ class Transitions:
             labels=structure.labels,
         )
 
-    def occupancy_parts(self, n_parts: int) -> list[dict[int, int]]:
-        """Return [occupancy arrays][gemdat.transitions.Transitions.occupancy]
-        from parts."""
-        return [part.occupancy() for part in self.split(n_parts)]
-
     def split(self, n_parts: int = 10) -> list[Transitions]:
         """Split data into equal parts in time for statistics.
 

--- a/src/gemdat/transitions.py
+++ b/src/gemdat/transitions.py
@@ -182,7 +182,7 @@ class Transitions:
         occupancies = dict(zip(unq, counts))
 
         species = [{
-            site.specie.name: occupancies.get(i, 1)
+            site.specie.name: occupancies.get(i, 0)
         } for i, site in enumerate(structure)]
 
         return Structure(

--- a/src/gemdat/transitions.py
+++ b/src/gemdat/transitions.py
@@ -193,6 +193,11 @@ class Transitions:
             labels=structure.labels,
         )
 
+    def occupancy_parts(self, n_parts: int) -> list[dict[int, int]]:
+        """Return [occupancy arrays][gemdat.transitions.Transitions.occupancy]
+        from parts."""
+        return [part.occupancy() for part in self.split(n_parts)]
+
     def split(self, n_parts: int = 10) -> list[Transitions]:
         """Split data into equal parts in time for statistics.
 

--- a/tests/integration/sites_test.py
+++ b/tests/integration/sites_test.py
@@ -77,10 +77,46 @@ class TestSites:  # type: ignore
         assert structure[0].species.num_atoms == 0.4544
         assert structure.composition.num_atoms == 37.54026666666666
 
+    def test_occupancy_parts(self, vasp_transitions):
+        parts = vasp_transitions.split(5)
+        structures = [part.occupancy() for part in parts]
+
+        values1 = [structure[0].species.num_atoms for structure in structures]
+        assert values1 == [
+            0.11066666666666666, 0.708, 0.408, 0.62, 0.42533333333333334
+        ]
+
+        values2 = [structure[0].species.num_atoms for structure in structures]
+        assert values2 == [
+            46.65333333333334, 52.12933333333333, 56.989333333333306,
+            47.49199999999999, 47.437333333333314
+        ]
+
     def test_atom_locations(self, vasp_sites, vasp_transitions):
-        assert isclose(vasp_sites.atom_locations(vasp_transitions)['48h'],
-                       0.7820889,
-                       rel_tol=1e-4)
+        dct = vasp_sites.atom_locations(vasp_transitions)
+        assert dct == {'48h': 0.7820888888888887}
+
+    def test_atom_locations_parts(self, vasp_sites, vasp_transitions):
+        parts = vasp_transitions.split(5)
+        dcts = [vasp_sites.atom_locations(part) for part in parts]
+
+        assert dcts == [
+            {
+                '48h': 0.9719444444444446
+            },
+            {
+                '48h': 1.0860277777777776
+            },
+            {
+                '48h': 1.1872777777777772
+            },
+            {
+                '48h': 0.9894166666666665
+            },
+            {
+                '48h': 0.9882777777777774
+            },
+        ]
 
     def test_n_jumps(self, vasp_jumps):
         assert vasp_jumps.n_solo_jumps == 450

--- a/tests/integration/sites_test.py
+++ b/tests/integration/sites_test.py
@@ -10,6 +10,7 @@ from math import isclose
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
+from pymatgen.core import Structure
 
 
 @pytest.vaspxml_available
@@ -71,17 +72,28 @@ class TestSites:  # type: ignore
             np.array([[0, 0, 95], [4, 23, 95], [8, 28, 95]]))
 
     def test_occupancy(self, vasp_transitions):
-        occupancy = vasp_transitions.occupancy()
-        assert len(occupancy) == 95
-        assert sum(occupancy.values()) == 137026
-        assert list(occupancy.values())[::20] == [1704, 971, 351, 1508, 1104]
+        structure = vasp_transitions.occupancy()
+
+        assert len(structure) == 96
+        assert structure[0].species.num_atoms == 0.4544
+        assert structure.composition.num_atoms == 37.54026666666666
 
     def test_occupancy_parts(self, vasp_sites, vasp_transitions):
         parts = vasp_sites.occupancy_parts(vasp_transitions)
+
         assert len(parts) == self.n_parts
-        assert [sum(part.values()) for part in parts] == [
-            13592, 13898, 13819, 14028, 14022, 14470, 13200, 13419, 13286,
-            13292
+        assert all(isinstance(part, Structure) for part in parts)
+
+        assert [part[0].species.num_atoms for part in parts] == [
+            0.14933333333333335, 0.072, 0.7306666666666667, 0.6853333333333333,
+            0.2, 0.616, 0.6133333333333333, 0.6266666666666667,
+            0.6853333333333333, 0.16533333333333333
+        ]
+
+        assert [part.composition.num_atoms for part in parts] == [
+            57.24533333333334, 56.06133333333333, 61.85066666666668,
+            63.40799999999999, 66.39199999999998, 61.58666666666666,
+            57.19999999999999, 58.784, 58.42933333333332, 59.44533333333335
         ]
 
     def test_site_occupancy(self, vasp_sites, vasp_transitions):

--- a/tests/integration/sites_test.py
+++ b/tests/integration/sites_test.py
@@ -10,7 +10,6 @@ from math import isclose
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
-from pymatgen.core import Structure
 
 
 @pytest.vaspxml_available
@@ -78,57 +77,10 @@ class TestSites:  # type: ignore
         assert structure[0].species.num_atoms == 0.4544
         assert structure.composition.num_atoms == 37.54026666666666
 
-    def test_occupancy_parts(self, vasp_sites, vasp_transitions):
-        parts = vasp_sites.occupancy_parts(vasp_transitions)
-
-        assert len(parts) == self.n_parts
-        assert all(isinstance(part, Structure) for part in parts)
-
-        assert [part[0].species.num_atoms for part in parts] == [
-            0.14933333333333335, 0.072, 0.7306666666666667, 0.6853333333333333,
-            0.2, 0.616, 0.6133333333333333, 0.6266666666666667,
-            0.6853333333333333, 0.16533333333333333
-        ]
-
-        assert [part.composition.num_atoms for part in parts] == [
-            57.24533333333334, 56.06133333333333, 61.85066666666668,
-            63.40799999999999, 66.39199999999998, 61.58666666666666,
-            57.19999999999999, 58.784, 58.42933333333332, 59.44533333333335
-        ]
-
-    def test_site_occupancy(self, vasp_sites, vasp_transitions):
-        assert isclose(vasp_sites.site_occupancy(vasp_transitions)['48h'],
-                       0.380628,
-                       rel_tol=1e-4)
-
-    def test_site_occupancy_parts(self, vasp_sites, vasp_transitions):
-        assert len(
-            vasp_sites.site_occupancy_parts(vasp_transitions)) == self.n_parts
-        assert isclose(
-            vasp_sites.site_occupancy_parts(vasp_transitions)[0]['48h'],
-            0.37756,
-            rel_tol=1e-4)
-        assert isclose(
-            vasp_sites.site_occupancy_parts(vasp_transitions)[9]['48h'],
-            0.36922,
-            rel_tol=1e-4)
-
     def test_atom_locations(self, vasp_sites, vasp_transitions):
         assert isclose(vasp_sites.atom_locations(vasp_transitions)['48h'],
-                       0.761255,
+                       0.7820889,
                        rel_tol=1e-4)
-
-    def test_atom_locations_parts(self, vasp_sites, vasp_transitions):
-        assert len(
-            vasp_sites.atom_locations_parts(vasp_transitions)) == self.n_parts
-        assert isclose(
-            vasp_sites.atom_locations_parts(vasp_transitions)[0]['48h'],
-            0.755111,
-            rel_tol=1e-4)
-        assert isclose(
-            vasp_sites.atom_locations_parts(vasp_transitions)[9]['48h'],
-            0.738444,
-            rel_tol=1e-4)
 
     def test_n_jumps(self, vasp_jumps):
         assert vasp_jumps.n_solo_jumps == 450
@@ -136,7 +88,7 @@ class TestSites:  # type: ignore
         assert isclose(vasp_jumps.solo_fraction, 0.974026, abs_tol=1e-4)
 
     def test_rates(self, vasp_jumps):
-        rates = vasp_jumps.rates()
+        rates = vasp_jumps.rates(n_parts=10)
         assert isinstance(rates, dict)
         assert len(rates) == 1
 
@@ -145,15 +97,15 @@ class TestSites:  # type: ignore
         assert isclose(rates_std, 41893421993.683655)
 
     def test_activation_energies(self, vasp_jumps, vasp_sites):
-        activation_energies = vasp_jumps.activation_energies()
+        activation_energies = vasp_jumps.activation_energies(n_parts=10)
 
         assert isinstance(activation_energies, dict)
         assert len(activation_energies) == 1
 
         e_act, e_act_std = activation_energies[('48h', '48h')]
 
-        assert isclose(e_act, 0.1744591, abs_tol=1e-4)
-        assert isclose(e_act_std, .00405951, abs_tol=1e-6)
+        assert isclose(e_act, 0.20223, abs_tol=1e-4)
+        assert isclose(e_act_std, 0.00595, abs_tol=1e-6)
 
     def test_jump_diffusivity(self, vasp_jumps):
         assert isclose(vasp_jumps.jump_diffusivity(3),

--- a/tests/integration/sites_test.py
+++ b/tests/integration/sites_test.py
@@ -75,7 +75,7 @@ class TestSites:  # type: ignore
 
         assert len(structure) == 96
         assert structure[0].species.num_atoms == 0.4544
-        assert structure.composition.num_atoms == 37.54026666666666
+        assert structure.composition.num_atoms == 36.54026666666665
 
     def test_occupancy_parts(self, vasp_transitions):
         parts = vasp_transitions.split(5)
@@ -86,15 +86,15 @@ class TestSites:  # type: ignore
             0.11066666666666666, 0.708, 0.408, 0.62, 0.42533333333333334
         ]
 
-        values2 = [structure[0].species.num_atoms for structure in structures]
+        values2 = [structure.composition.num_atoms for structure in structures]
         assert values2 == [
-            46.65333333333334, 52.12933333333333, 56.989333333333306,
-            47.49199999999999, 47.437333333333314
+            36.653333333333336, 37.129333333333335, 37.98933333333333,
+            35.49199999999999, 35.43733333333334
         ]
 
     def test_atom_locations(self, vasp_sites, vasp_transitions):
         dct = vasp_sites.atom_locations(vasp_transitions)
-        assert dct == {'48h': 0.7820888888888887}
+        assert dct == {'48h': 0.7612555555555552}
 
     def test_atom_locations_parts(self, vasp_sites, vasp_transitions):
         parts = vasp_transitions.split(5)
@@ -102,19 +102,19 @@ class TestSites:  # type: ignore
 
         assert dcts == [
             {
-                '48h': 0.9719444444444446
+                '48h': 0.7636111111111111
             },
             {
-                '48h': 1.0860277777777776
+                '48h': 0.7735277777777778
             },
             {
-                '48h': 1.1872777777777772
+                '48h': 0.7914444444444443
             },
             {
-                '48h': 0.9894166666666665
+                '48h': 0.7394166666666665
             },
             {
-                '48h': 0.9882777777777774
+                '48h': 0.7382777777777779
             },
         ]
 
@@ -140,8 +140,8 @@ class TestSites:  # type: ignore
 
         e_act, e_act_std = activation_energies[('48h', '48h')]
 
-        assert isclose(e_act, 0.20223, abs_tol=1e-4)
-        assert isclose(e_act_std, 0.00595, abs_tol=1e-6)
+        assert isclose(e_act, 0.17445, abs_tol=1e-4)
+        assert isclose(e_act_std, 0.004059, abs_tol=1e-6)
 
     def test_jump_diffusivity(self, vasp_jumps):
         assert isclose(vasp_jumps.jump_diffusivity(3),


### PR DESCRIPTION
This PR changes how the occupancies are returned. The currently returned as a dictionary with indexes, which is inconvenient. This PR changes the return type to a Structure, with the occupancies set through the composition.

Closes #244

### Todo

- [x] Clean up code
- [x] Add/update tests
- [x] Deprecate "_parts" methods, use `.split()` and normal methods instead
