### PR TITLE
Fix wrong `n_floating` bug

### DIFF
--- a/src/gemdat/jumps.py
+++ b/src/gemdat/jumps.py
@@ -151,7 +151,7 @@ class Jumps:
     @property
     def n_floating(self) -> int:
         """Return number of floating species."""
-        return len(self.transitions.trajectory.species)
+        return self.transitions.n_floating
 
     @property
     def solo_fraction(self) -> float:

--- a/src/gemdat/transitions.py
+++ b/src/gemdat/transitions.py
@@ -125,7 +125,7 @@ class Transitions:
                   dist_close=dist_close,
                   n_steps=len(trajectory),
                   n_sites=len(structure),
-                  trajectory=trajectory)
+                  trajectory=diff_trajectory)
 
         return obj
 

--- a/src/gemdat/transitions.py
+++ b/src/gemdat/transitions.py
@@ -129,6 +129,11 @@ class Transitions:
 
         return obj
 
+    @property
+    def n_floating(self) -> int:
+        """Return number of floating species."""
+        return len(self.trajectory.species)
+
     @weak_lru_cache()
     def matrix(self) -> np.ndarray:
         """Convert list of transition events to dense matrix.

--- a/tests/integration/sites_test.py
+++ b/tests/integration/sites_test.py
@@ -135,8 +135,8 @@ class TestSites:  # type: ignore
 
         row = rates.loc[('48h', '48h')]
 
-        assert isclose(row['rates'], 1249999999999.9998)
-        assert isclose(row['std'], 137337009020.29002)
+        assert isclose(row['rates'], 1174999999999.9998)
+        assert isclose(row['std'], 90769080986.31458)
 
     def test_activation_energies(self, vasp_jumps, vasp_sites):
         activation_energies = vasp_jumps.activation_energies(n_parts=10)
@@ -146,19 +146,19 @@ class TestSites:  # type: ignore
 
         row = activation_energies.loc[('48h', '48h')]
 
-        assert isclose(row['energy'], 0.1311852, abs_tol=1e-4)
-        assert isclose(row['std'], 0.00596132, abs_tol=1e-6)
+        assert isclose(row['energy'], 0.134486, abs_tol=1e-4)
+        assert isclose(row['std'], 0.00405952, abs_tol=1e-6)
 
     def test_jump_diffusivity(self, vasp_jumps):
         assert isclose(vasp_jumps.jump_diffusivity(3),
-                       9.220713700212185e-09,
+                       9.484382e-09,
                        rel_tol=1e-6)
 
     def test_correlation_factor(self, vasp_sites, vasp_jumps):
         tracer_diff = vasp_sites.metrics.tracer_diffusivity(dimensions=3)
         correlation_factor = tracer_diff / vasp_jumps.jump_diffusivity(
             dimensions=3)
-        assert isclose(correlation_factor, 0.1703355120150192, rel_tol=1e-6)
+        assert isclose(correlation_factor, 0.165600, rel_tol=1e-6)
 
     def test_collective(self, vasp_jumps):
         collective = vasp_jumps.collective()

--- a/tests/integration/sites_test.py
+++ b/tests/integration/sites_test.py
@@ -135,8 +135,8 @@ class TestSites:  # type: ignore
 
         row = rates.loc[('48h', '48h')]
 
-        assert isclose(row['rates'], 542307692307.69226)
-        assert isclose(row['std'], 41893421993.683655)
+        assert isclose(row['rates'], 1249999999999.9998)
+        assert isclose(row['std'], 137337009020.29002)
 
     def test_activation_energies(self, vasp_jumps, vasp_sites):
         activation_energies = vasp_jumps.activation_energies(n_parts=10)
@@ -146,19 +146,19 @@ class TestSites:  # type: ignore
 
         row = activation_energies.loc[('48h', '48h')]
 
-        assert isclose(row['energy'], 0.17445, abs_tol=1e-4)
-        assert isclose(row['std'], 0.004059, abs_tol=1e-6)
+        assert isclose(row['energy'], 0.1311852, abs_tol=1e-4)
+        assert isclose(row['std'], 0.00596132, abs_tol=1e-6)
 
     def test_jump_diffusivity(self, vasp_jumps):
         assert isclose(vasp_jumps.jump_diffusivity(3),
-                       4.377407272861394e-09,
+                       9.220713700212185e-09,
                        rel_tol=1e-6)
 
     def test_correlation_factor(self, vasp_sites, vasp_jumps):
         tracer_diff = vasp_sites.metrics.tracer_diffusivity(dimensions=3)
         correlation_factor = tracer_diff / vasp_jumps.jump_diffusivity(
             dimensions=3)
-        assert isclose(correlation_factor, 0.3588002877883636, rel_tol=1e-6)
+        assert isclose(correlation_factor, 0.1703355120150192, rel_tol=1e-6)
 
     def test_collective(self, vasp_jumps):
         collective = vasp_jumps.collective()

--- a/tests/integration/sites_test.py
+++ b/tests/integration/sites_test.py
@@ -48,9 +48,13 @@ class TestSites:  # type: ignore
         # https://github.com/GEMDAT-repos/GEMDAT/issues/252
         assert vasp_transitions.n_floating == 48
 
-    def test_all_transitions(self, vasp_sites, vasp_transitions):
+    def test_n_states(self, vasp_transitions):
+        assert vasp_transitions.n_states == 3750
 
+    def test_all_transitions(self, vasp_sites, vasp_transitions):
         events = vasp_transitions.events
+
+        assert vasp_transitions.n_events == 2105
         assert vasp_transitions.events.shape == (2105, 6)
         assert_allclose(
             events[::1000],

--- a/tests/integration/sites_test.py
+++ b/tests/integration/sites_test.py
@@ -44,6 +44,10 @@ class TestSites:  # type: ignore
         assert_allclose(states_prev[slice_],
                         np.array([[94, -1], [94, 65], [0, 65], [0, 65]]))
 
+    def test_n_floating(self, vasp_transitions):
+        # https://github.com/GEMDAT-repos/GEMDAT/issues/252
+        assert vasp_transitions.n_floating == 48
+
     def test_all_transitions(self, vasp_sites, vasp_transitions):
 
         events = vasp_transitions.events


### PR DESCRIPTION
This PR proposes a possible fix for #252. I believe diff_trajectory must be stored on Transitions instead of Trajectory.

Closes #252 

### Todo

- [x] Add test for n_floating
- [x] Change variable names to make more clear what it does
- [x] Check numbers from test with previous
- [x] test_rates
- [x] test_activation_energies
- [x] test_jump_diffusivity (used to be: 9.220713700212185e-09)
- [x] test_correlation_factor (used to be: 0.1703355120150192)
