### PR TITLE
Tweak method names and update default dimensions

### DIFF
--- a/src/gemdat/rotations.py
+++ b/src/gemdat/rotations.py
@@ -215,9 +215,9 @@ class Orientations:
 
         return replace(self, in_vectors=vectors)
 
-    def conventional(self, prim_to_conv_matrix: np.ndarray) -> Orientations:
-        """Convert the trajectory of unit vectors from fractional to
-        conventional coordinates.
+    def transform(self, matrix: np.ndarray) -> Orientations:
+        """Convert the trajectory of unit vectors e.g. from primitive to
+        conventional setting.
 
         A conventional unit cell only contains one lattice point, while the
         primitive cell contains the Bravais lattice. This means that the
@@ -227,17 +227,17 @@ class Orientations:
 
         Parameters
         ----------
-        prim_to_conv_matrix: np.array
+        matrix: np.array
             Matrix for vector transformation
 
         Returns
         -------
-        Orientations
+        orientations : Orientations
         """
-        if prim_to_conv_matrix.shape != (3, 3):
-            raise ValueError('prim_to_conv_matrix must be a 3x3 matrix')
+        if matrix.shape != (3, 3):
+            raise ValueError('matrix must be a 3x3 matrix')
 
-        vectors = np.dot(self.vectors, prim_to_conv_matrix.T)
+        vectors = np.dot(self.vectors, matrix.T)
 
         return replace(self, in_vectors=vectors)
 

--- a/src/gemdat/simulation_metrics.py
+++ b/src/gemdat/simulation_metrics.py
@@ -73,7 +73,7 @@ class SimulationMetrics:
         return FloatWithUnit(mol_per_liter, 'mol l^-1')
 
     @weak_lru_cache()
-    def tracer_diffusivity(self, *, dimensions: int) -> FloatWithUnit:
+    def tracer_diffusivity(self, *, dimensions: int = 3) -> FloatWithUnit:
         """Calculate tracer diffusivity.
 
         Defined as: MSD / (2*dimensions*time)
@@ -96,8 +96,13 @@ class SimulationMetrics:
 
         return FloatWithUnit(tracer_diff, 'm^2 s^-1')
 
-    def ionic_conductivity(self, *, dimensions: int) -> FloatWithUnit:
-        """Calculate ionic conductivity.
+    @weak_lru_cache()
+    def tracer_diffusivity_center_of_mass(
+        self,
+        *,
+        dimensions: int = 3,
+    ) -> FloatWithUnit:
+        """Calculate the tracer diffusivity of the center of mass.
 
         Parameters
         ----------
@@ -106,17 +111,17 @@ class SimulationMetrics:
 
         Returns
         -------
-        ionic_conductivity : FloatWithUnit
+        tracer_diffusivity : FloatWithUnit
             Tracer diffusivity in $m^2/s$
         """
         center_of_mass = self.trajectory.center_of_mass()
 
         metrics = SimulationMetrics(center_of_mass)
 
-        return metrics.tracer_diffusivity(dimensions=3)
+        return metrics.tracer_diffusivity(dimensions=dimensions)
 
     @weak_lru_cache()
-    def haven_ratio(self, *, dimensions: int) -> float:
+    def haven_ratio(self, *, dimensions: int = 3) -> float:
         """Calculate Haven's ratio.
 
         Parameters
@@ -126,15 +131,17 @@ class SimulationMetrics:
 
         Returns
         -------
-        ionic_conductivity : float
+        haven_ratio : float
         """
         return self.tracer_diffusivity(
-            dimensions=dimensions) / self.ionic_conductivity(
+            dimensions=dimensions) / self.tracer_diffusivity_center_of_mass(
                 dimensions=dimensions)
 
     @weak_lru_cache()
-    def tracer_conductivity(self, *, z_ion: int,
-                            dimensions: int) -> FloatWithUnit:
+    def tracer_conductivity(self,
+                            *,
+                            z_ion: int,
+                            dimensions: int = 3) -> FloatWithUnit:
         """Return tracer conductivity as S/m.
 
         Defined as: elementary_charge^2 * charge_ion^2 * diffusivity *

--- a/tests/integration/plot_test.py
+++ b/tests/integration/plot_test.py
@@ -90,12 +90,11 @@ def test_path_energy(vasp_full_vol, vasp_full_path):
 
 @image_comparison2(baseline_images=['rectilinear'])
 def test_rectilinear(vasp_orientations):
-    prim_to_conv_matrix = np.array(
+    matrix = np.array(
         [[1 / 2**0.5, -1 / 6**0.5, 1 / 3**0.5],
          [1 / 2**0.5, 1 / 6**0.5, -1 / 3**0.5], [0, 2 / 6**0.5, 1 / 3**0.5]], )
 
-    orientations = vasp_orientations.normalize().conventional(
-        prim_to_conv_matrix=prim_to_conv_matrix)
+    orientations = vasp_orientations.normalize().transform(matrix=matrix)
     plots.rectilinear_plot(orientations=orientations, normalize_histo=False)
 
 

--- a/tests/integration/rotations_test.py
+++ b/tests/integration/rotations_test.py
@@ -7,7 +7,7 @@ import pytest
 
 from gemdat.rotations import calculate_spherical_areas
 
-PRIM_TO_CONV_MATRIX = np.array(
+matrix = np.array(
     [[1 / 2**0.5, -1 / 6**0.5, 1 / 3**0.5],
      [1 / 2**0.5, 1 / 6**0.5, -1 / 3**0.5], [0, 2 / 6**0.5, 1 / 3**0.5]], )
 
@@ -23,8 +23,7 @@ def test_normalize(vasp_orientations):
 
 @pytest.vasprotocache_available  # type: ignore
 def test_conventional(vasp_orientations):
-    ret = vasp_orientations.conventional(
-        prim_to_conv_matrix=PRIM_TO_CONV_MATRIX)
+    ret = vasp_orientations.transform(matrix=matrix)
     assert isclose(ret.vectors.std(), 0.8668510720176622)
     first = ret.vectors[0, 0]
     np.testing.assert_allclose(first, [-0.712261, 1.378551, -0.213198],
@@ -51,8 +50,8 @@ def test_normalize_symmetrize(vasp_orientations):
 
 @pytest.vasprotocache_available  # type: ignore
 def test_normalize_conventional_symmetrize(vasp_orientations):
-    ret = vasp_orientations.normalize().conventional(
-        prim_to_conv_matrix=PRIM_TO_CONV_MATRIX).symmetrize(sym_group='m-3m')
+    ret = vasp_orientations.normalize().transform(matrix=matrix).symmetrize(
+        sym_group='m-3m')
     assert isclose(ret.vectors.std(), 0.577350269189626)
     first = ret.vectors[0, 0]
     np.testing.assert_allclose(first, [0.136119, -0.880154, 0.454753],
@@ -61,9 +60,8 @@ def test_normalize_conventional_symmetrize(vasp_orientations):
 
 @pytest.vasprotocache_available  # type: ignore
 def test_conventional_normalize_symmetrize(vasp_orientations):
-    ret = vasp_orientations.conventional(
-        prim_to_conv_matrix=PRIM_TO_CONV_MATRIX).normalize().symmetrize(
-            sym_group='m-3m')
+    ret = vasp_orientations.transform(matrix=matrix).normalize().symmetrize(
+        sym_group='m-3m')
     assert isclose(ret.vectors.std(), 0.577350269189626)
     first = ret.vectors[0, 0]
     np.testing.assert_allclose(first, [0.136119, -0.880154, 0.454753],

--- a/tests/integration/trajectory_test.py
+++ b/tests/integration/trajectory_test.py
@@ -60,7 +60,7 @@ def test_metrics_other(vasp_traj):
     assert isclose(metrics.particle_density(), 2.4557e28, rel_tol=1e-4)
     assert isclose(metrics.mol_per_liter(), 40.777, rel_tol=1e-4)
     assert isclose(
-        metrics.tracer_conductivity(z_ion=1, dimensions=3),
+        metrics.tracer_conductivity(z_ion=1),
         110.322,
         rel_tol=1e-4,
     )
@@ -72,16 +72,16 @@ def test_metrics_haven(vasp_traj):
     metrics = SimulationMetrics(diff_trajectory)
 
     assert isclose(
-        metrics.tracer_diffusivity(dimensions=3),
+        metrics.tracer_diffusivity(),
         1.5706e-09,
         rel_tol=1e-4,
     )
     assert isclose(
-        metrics.ionic_conductivity(dimensions=3),
+        metrics.tracer_diffusivity_center_of_mass(),
         5.38169e-11,
         rel_tol=1e-4,
     )
-    assert isclose(metrics.haven_ratio(dimensions=3), 29.1844, rel_tol=1e-4)
+    assert isclose(metrics.haven_ratio(), 29.1844, rel_tol=1e-4)
 
 
 @pytest.vaspxml_available  # type: ignore

--- a/tests/rotations_test.py
+++ b/tests/rotations_test.py
@@ -44,8 +44,8 @@ def test_conventional(trajectory):
                                 in_vectors=np.array(
                                     [[1, 0, 0], [0, 1, 0], [0, 0, 1]],
                                     dtype=float))
-    prim_to_conv_matrix = np.eye(3) * [1, 2, 3]
-    ret = orientations.conventional(prim_to_conv_matrix=prim_to_conv_matrix)
+    matrix = np.eye(3) * [1, 2, 3]
+    ret = orientations.transform(matrix=matrix)
     assert np.allclose(ret.vectors, np.array([[1, 0, 0], [0, 2, 0], [0, 0,
                                                                      3]]))
 


### PR DESCRIPTION
This PR makes some small changes to the code after discussions with @v9lgraf @tfamprikis 

1. Rename `ionic_conductivity` to `tracer_diffucivity_center_of_mass`. 
2. Set default `dimensions=3` (it can still be configured)
3. Rename `Orientations.conventional()` -> `Orientations.transform()`