### PR TITLE
Move legacy.py out of main library

### DIFF
--- a/docs/api/gemdat_legacy.md
+++ b/docs/api/gemdat_legacy.md
@@ -1,4 +1,0 @@
-::: gemdat.legacy
-    options:
-      show_root_heading: false
-      show_root_toc_entry: false

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,7 +23,6 @@ nav:
     - gemdat: api/gemdat.md
     - gemdat.collective: api/gemdat_collective.md
     - gemdat.io: api/gemdat_io.md
-    - gemdat.legacy: api/gemdat_legacy.md
     - gemdat.plots: api/gemdat_plots.md
     - gemdat.rdf: api/gemdat_rdf.md
     - gemdat.simulation_metrics: api/gemdat_simulation_metrics.md

--- a/scripts/analyse_md.py
+++ b/scripts/analyse_md.py
@@ -93,17 +93,22 @@ def analyse_md(
 
     jumps = Jumps(transitions=transitions)
 
-    plots.displacement_per_element(trajectory=trajectory)
-    plots.displacement_per_atom(trajectory=diff_trajectory)
-    plots.displacement_histogram(trajectory=diff_trajectory)
-    plots.frequency_vs_occurence(trajectory=diff_trajectory)
-    plots.vibrational_amplitudes(trajectory=diff_trajectory)
-    plots.jumps_vs_distance(jumps=jumps, jump_res=jump_res)
-    plots.jumps_vs_time(jumps=jumps)
-    plots.collective_jumps(jumps=jumps)
-    plots.jumps_3d(jumps=jumps)
+    figs = [
+        plots.displacement_per_element(trajectory=trajectory),
+        plots.displacement_per_atom(trajectory=diff_trajectory),
+        plots.displacement_histogram(trajectory=diff_trajectory),
+        plots.frequency_vs_occurence(trajectory=diff_trajectory),
+        plots.vibrational_amplitudes(trajectory=diff_trajectory),
+        plots.jumps_vs_distance(jumps=jumps, jump_res=jump_res),
+        plots.jumps_vs_time(jumps=jumps),
+        plots.collective_jumps(jumps=jumps),
+        plots.jumps_3d(jumps=jumps),
+    ]
+    if show_plots:
+        for fig in figs:
+            fig.show()
 
-    _tmp = plots.jumps_3d_animation(  # Assignment needed to not desctruct animation before plt.show()
+    _tmp = plots.jumps_3d_animation(
         jumps=jumps,
         t_start=start_end[0],
         t_stop=start_end[1],
@@ -133,7 +138,18 @@ def analyse_md(
             max_dist=rdf_max_dist,
             resolution=rdf_res,
         )
-        for rdfs in rdf_data.values():
-            plots.radial_distribution(rdfs)
+
+        figs = [plots.radial_distribution(rdfs) for rdfs in rdf_data.values()]
+        if show_plots:
+            for fig in figs:
+                fig.show()
 
     return trajectory
+
+
+if __name__ == '__main__':
+    analyse_md(
+        vasp_xml='vasprun.xml',
+        diff_elem='Li',
+        material='argyrodite',
+    )


### PR DESCRIPTION
This PR moves the legacy interface to its own file mimicking analyse_md from the matlab code.

Closes #314