### PR TITLE
Add shortcut for calculating and plotting RDFs

### DIFF
--- a/src/gemdat/__init__.py
+++ b/src/gemdat/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from .io import load_known_material, read_cif
 from .jumps import Jumps
 from .orientations import Orientations
+from .rdf import radial_distribution
 from .shape import ShapeAnalyzer
 from .simulation_metrics import SimulationMetrics
 from .trajectory import Trajectory
@@ -14,6 +15,7 @@ __all__ = [
     'Jumps',
     'load_known_material',
     'Orientations',
+    'radial_distribution',
     'read_cif',
     'ShapeAnalyzer',
     'SimulationMetrics',

--- a/src/gemdat/plots/__init__.py
+++ b/src/gemdat/plots/__init__.py
@@ -3,27 +3,27 @@
 from __future__ import annotations
 
 from .matplotlib import (
-    autocorrelation,
-    bond_length_distribution,
-    energy_along_path,
     jumps_3d_animation,
-    radial_distribution,
-    rectilinear,
     shape,
 )
 
 from .plotly import (
+    autocorrelation,
+    bond_length_distribution,
     collective_jumps,
     density,
     displacement_histogram,
     displacement_per_atom,
     displacement_per_element,
+    energy_along_path,
     frequency_vs_occurence,
     jumps_3d,
     jumps_vs_distance,
     jumps_vs_time,
     msd_per_element,
     plot_3d,
+    radial_distribution,
+    rectilinear,
     vibrational_amplitudes,
 )
 

--- a/src/gemdat/rdf.py
+++ b/src/gemdat/rdf.py
@@ -93,6 +93,16 @@ class RDFData:
         """See [gemdat.plots.radial_distribution][] for more info."""
         from gemdat import plots
 
+        return plots.radial_distribution(rdfs=[self], **kwargs)
+
+
+class RDFCollection(list[RDFData]):
+    """Collection to store group of radial distribution data."""
+
+    def plot(self, **kwargs):
+        """See [gemdat.plots.radial_distribution][] for more info."""
+        from gemdat import plots
+
         return plots.radial_distribution(rdfs=self, **kwargs)
 
 
@@ -102,7 +112,7 @@ def radial_distribution(
     floating_specie: str,
     max_dist: float = 5.0,
     resolution: float = 0.1,
-) -> dict[str, list[RDFData]]:
+) -> dict[str, RDFCollection]:
     """Calculate and sum RDFs for the floating species in the given sites data.
 
     Parameters
@@ -118,7 +128,7 @@ def radial_distribution(
 
     Returns
     -------
-    rdfs : dict[str, np.ndarray]
+    rdfs : dict[str, RDFCollection]
         Dictionary with rdf arrays per symbol
     """
     # note: needs trajectory with ALL species
@@ -163,7 +173,7 @@ def radial_distribution(
                 rdf_state = rdf[k_idx, symbol_idx].flatten()
                 rdfs[state_str, symbol] += np.bincount(rdf_state, minlength=length)
 
-    ret: dict[str, list[RDFData]] = {}
+    ret: dict[str, RDFCollection] = {}
 
     for (state, symbol), values in rdfs.items():
         rdf_data = RDFData(
@@ -173,7 +183,7 @@ def radial_distribution(
             symbol=symbol,
             state=state,
         )
-        ret.setdefault(state, [])
+        ret.setdefault(state, RDFCollection())
         ret[state].append(rdf_data)
 
     return ret

--- a/src/gemdat/transitions.py
+++ b/src/gemdat/transitions.py
@@ -147,15 +147,11 @@ class Transitions:
 
         return obj
 
-    def jumps(self, minimal_residence: int = 0, **kwargs) -> Jumps:
+    def jumps(self, **kwargs) -> Jumps:
         """Analyze transitions and classify them as jumps.
 
         Parameters
         ----------
-        minimal_residence : int
-            minimal residence, number of timesteps that an atom needs to reside
-            on a destination site to count as a jump, passed through to conversion
-            method
         **kwargs : dict
             These parameters are passed to the [gemdat.Jumps][] initializer.
 
@@ -163,7 +159,6 @@ class Transitions:
         -------
         jumps : Jumps
         """
-
         from gemdat.jumps import Jumps
 
         return Jumps(self, **kwargs)

--- a/src/gemdat/transitions.py
+++ b/src/gemdat/transitions.py
@@ -19,6 +19,7 @@ from .utils import bfill, ffill, integer_remap
 if typing.TYPE_CHECKING:
     from gemdat.jumps import Jumps
     from gemdat.trajectory import Trajectory
+    from gemdat.rdf import RDFCollection
 
 NOSITE = -1
 
@@ -162,6 +163,25 @@ class Transitions:
         from gemdat.jumps import Jumps
 
         return Jumps(self, **kwargs)
+
+    def radial_distribution(self, **kwargs) -> dict[str, RDFCollection]:
+        """Calculate and sum RDFs for the floating species in the given sites
+        data.
+
+        Parameters
+        ----------
+        **kwargs : dict
+            These parameters are passed to the [gemdat.radial_distribution][] function.
+
+
+        Returns
+        -------
+        rdfs : dict[str, RDFCollection]
+            Dictionary with rdf arrays per symbol
+        """
+        from gemdat.rdf import radial_distribution
+
+        return radial_distribution(transitions=self, **kwargs)
 
     @property
     def n_floating(self) -> int:


### PR DESCRIPTION
This PR makes it easier to calculate and plot RDFs.

```python
rdf_data = transitions.radial_distribution(
    floating_specie='Li',
)

for rdfs in rdf_data.values():
    fig = rdfs.plot()
    fig.show()
```

Closes https://github.com/GEMDAT-repos/gemdat-notebooks/issues/12