### PR TITLE
Add method to create a graph from jumps

### DIFF
--- a/src/gemdat/trajectory.py
+++ b/src/gemdat/trajectory.py
@@ -19,6 +19,7 @@ from pymatgen.io import vasp
 if TYPE_CHECKING:
     from pymatgen.core import Structure
 
+    from .metrics import SimulationMetrics
     from .transitions import Transitions
     from .volume import Volume
 
@@ -519,6 +520,12 @@ class Trajectory(PymatgenTrajectory):
             site_radius=site_radius,
             site_inner_fraction=site_inner_fraction,
         )
+
+    def metrics(self) -> SimulationMetrics:
+        """See [gemdat.SimulationMetrics][] for more info."""
+        from .metrics import SimulationMetrics
+
+        return SimulationMetrics(trajectory=self)
 
     def plot_displacement_per_atom(self, **kwargs):
         """See [gemdat.plots.displacement_per_atom][] for more info."""


### PR DESCRIPTION
This PR makes an attempt to calculate the activation energy graph from the jumps object.

```python
>>> from gemdat import Trajectory, load_known_material
>>> from gemdat.utils import VASPRUN
>>> 
>>> trajectory = Trajectory.from_vasprun(VASPRUN)
>>> diff_trajectory = trajectory.filter('Li')
>>> 
>>> sites = load_known_material('argyrodite', supercell=(2, 1, 1))
>>> sites_relabel_sites()  # sites must have an unique label
>>> 
>>> transitions = trajectory.transitions_between_sites(
>>>     sites=sites,
>>>     floating_specie='Li',
>>> )
>>> 
>>> jumps = transitions.jumps()
>>> G = jumps.to_graph()
>>> list(G.adjacency())
[('48h_95',
  {'48h_1': {'ae': 0.08184877863639753},
   '48h_87': {'ae': 0.17199768720154068}}),
 ('48h_1',
  {'48h_95': {'ae': 0.07200775957630277},
   '48h_65': {'ae': 0.20098168979635483}}),
 ('48h_87',
...
]
```

Closes #322