### PR TITLE
Add option to switch between plotting backends

### DIFF
--- a/src/gemdat/_plot_backend.py
+++ b/src/gemdat/_plot_backend.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+
+def plot_backend(func):
+    """Decorator to switch plotting backend."""
+
+    def wrap(*args, backend: str | None = None, **kwargs):
+        if backend is None:
+            from gemdat import plots as _backend
+        elif backend in ('mpl', 'matplotlib'):
+            from gemdat.plots import matplotlib as _backend
+        elif backend == 'plotly':
+            from gemdat.plots import plotly as _backend
+        else:
+            raise ValueError(f'No such backend: {backend}')
+
+        result = func(*args, _backend=_backend, **kwargs)
+
+        return result
+
+    wrap.__doc__ = func.__doc__
+    wrap.__doc__ += """
+
+Parameters
+---------
+backend : str
+    Choose plotting backend. Options: matplotlib, mpl, plotly
+    Defaults to plotly unless the plot is only available in matplotlib.
+
+Returns
+-------
+fig : plotly.graph_objects.Figure or matplotlib.figure.Figure depending on backend.
+    Output figure
+"""
+
+    return wrap

--- a/src/gemdat/_plot_backend.py
+++ b/src/gemdat/_plot_backend.py
@@ -1,20 +1,28 @@
 from __future__ import annotations
 
+from types import ModuleType
+
+from gemdat import plots as plots_default
+from gemdat.plots import matplotlib as plots_matplotlib
+from gemdat.plots import plotly as plots_plotly
+
 
 def plot_backend(func):
     """Decorator to switch plotting backend."""
 
     def wrap(*args, backend: str | None = None, **kwargs):
+        module: ModuleType
+
         if backend is None:
-            from gemdat import plots as _backend
+            module = plots_default
         elif backend in ('mpl', 'matplotlib'):
-            from gemdat.plots import matplotlib as _backend
+            module = plots_matplotlib
         elif backend == 'plotly':
-            from gemdat.plots import plotly as _backend
+            module = plots_plotly
         else:
             raise ValueError(f'No such backend: {backend}')
 
-        result = func(*args, _backend=_backend, **kwargs)
+        result = func(*args, module=module, **kwargs)
 
         return result
 

--- a/src/gemdat/jumps.py
+++ b/src/gemdat/jumps.py
@@ -10,6 +10,7 @@ import pandas as pd
 from pymatgen.core.units import FloatWithUnit
 from scipy.constants import Boltzmann, angstrom, elementary_charge
 
+from ._plot_backend import plot_backend
 from .caching import weak_lru_cache
 from .collective import Collective
 from .simulation_metrics import SimulationMetrics
@@ -353,32 +354,27 @@ class Jumps:
 
         return df
 
-    def plot_jumps_vs_distance(self, **kwargs):
+    @plot_backend
+    def plot_jumps_vs_distance(self, *, module, **kwargs):
         """See [gemdat.plots.jumps_vs_distance][] for more information."""
-        from gemdat import plots
+        return module.jumps_vs_distance(jumps=self, **kwargs)
 
-        return plots.jumps_vs_distance(jumps=self, **kwargs)
-
-    def plot_jumps_vs_time(self, **kwargs):
+    @plot_backend
+    def plot_jumps_vs_time(self, *, module, **kwargs):
         """See [gemdat.plots.jumps_vs_time][] for more information."""
-        from gemdat import plots
+        return module.jumps_vs_time(jumps=self, **kwargs)
 
-        return plots.jumps_vs_time(jumps=self, **kwargs)
-
-    def plot_collective_jumps(self, **kwargs):
+    @plot_backend
+    def plot_collective_jumps(self, *, module, **kwargs):
         """See [gemdat.plots.collective_jumps][] for more information."""
-        from gemdat import plots
+        return module.collective_jumps(jumps=self, **kwargs)
 
-        return plots.collective_jumps(jumps=self, **kwargs)
-
-    def plot_jumps_3d(self, **kwargs):
+    @plot_backend
+    def plot_jumps_3d(self, *, module, **kwargs):
         """See [gemdat.plots.jumps_3d][] for more information."""
-        from gemdat import plots
+        return module.jumps_3d(jumps=self, **kwargs)
 
-        return plots.jumps_3d(jumps=self, **kwargs)
-
-    def plot_jumps_3d_animation(self, **kwargs):
+    @plot_backend
+    def plot_jumps_3d_animation(self, *, module, **kwargs):
         """See [gemdat.plots.jumps_3d_animation][] for more information."""
-        from gemdat import plots
-
-        return plots.jumps_3d_animation(jumps=self, **kwargs)
+        return module.jumps_3d_animation(jumps=self, **kwargs)

--- a/src/gemdat/orientations.py
+++ b/src/gemdat/orientations.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
 from dataclasses import InitVar, dataclass, field, replace
+from typing import TYPE_CHECKING
 
 import numpy as np
 from pymatgen.symmetry.groups import PointGroup
 
-from gemdat.trajectory import Trajectory
 from gemdat.utils import cartesian_to_spherical, fft_autocorrelation
 
 from ._plot_backend import plot_backend
+
+if TYPE_CHECKING:
+    from gemdat.trajectory import Trajectory
 
 
 @dataclass

--- a/src/gemdat/orientations.py
+++ b/src/gemdat/orientations.py
@@ -8,6 +8,8 @@ from pymatgen.symmetry.groups import PointGroup
 from gemdat.trajectory import Trajectory
 from gemdat.utils import cartesian_to_spherical, fft_autocorrelation
 
+from ._plot_backend import plot_backend
+
 
 @dataclass
 class Orientations:
@@ -259,23 +261,20 @@ class Orientations:
         """Compute the autocorrelation of the orientation vectors using FFT."""
         return fft_autocorrelation(self.vectors)
 
-    def plot_rectilinear(self, **kwargs):
+    @plot_backend
+    def plot_rectilinear(self, *, module, **kwargs):
         """See [gemdat.plots.rectilinear][] for more info."""
-        from gemdat import plots
+        return module.rectilinear(orientations=self, **kwargs)
 
-        return plots.rectilinear(orientations=self, **kwargs)
-
-    def plot_bond_length_distribution(self, **kwargs):
+    @plot_backend
+    def plot_bond_length_distribution(self, *, module, **kwargs):
         """See [gemdat.plots.bond_length_distribution][] for more info."""
-        from gemdat import plots
+        return module.bond_length_distribution(orientations=self, **kwargs)
 
-        return plots.bond_length_distribution(orientations=self, **kwargs)
-
-    def plot_autocorrelation(self, **kwargs):
+    @plot_backend
+    def plot_autocorrelation(self, *, module, **kwargs):
         """See [gemdat.plots.unit_vector_autocorrelation][] for more info."""
-        from gemdat import plots
-
-        return plots.autocorrelation(orientations=self, **kwargs)
+        return module.autocorrelation(orientations=self, **kwargs)
 
 
 def calculate_spherical_areas(shape: tuple[int, int], radius: float = 1) -> np.ndarray:

--- a/src/gemdat/path.py
+++ b/src/gemdat/path.py
@@ -15,6 +15,7 @@ from pymatgen.core.units import FloatWithUnit
 
 from gemdat.volume import FreeEnergyVolume
 
+from ._plot_backend import plot_backend
 from .utils import nearest_structure_reference
 
 if TYPE_CHECKING:
@@ -142,17 +143,15 @@ class Pathway:
         """Return stop site."""
         return self.sites[-1]
 
-    def plot_energy_along_path(self, **kwargs):
+    @plot_backend
+    def plot_energy_along_path(self, module, **kwargs):
         """See [gemdat.plots.energy_along_path][] for more info."""
-        from gemdat import plots
+        return module.energy_along_path(path=self, **kwargs)
 
-        return plots.energy_along_path(path=self, **kwargs)
-
-    def plot_path_on_grid(self, **kwargs):
+    @plot_backend
+    def plot_path_on_grid(self, module, **kwargs):
         """See [gemdat.plots.path_on_grid][] for more info."""
-        from gemdat import plots
-
-        return plots.path_on_grid(path=self, **kwargs)
+        return module.path_on_grid(path=self, **kwargs)
 
 
 def free_energy_graph(

--- a/src/gemdat/plots/matplotlib/_autocorrelation.py
+++ b/src/gemdat/plots/matplotlib/_autocorrelation.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import matplotlib.pyplot as plt
 import numpy as np
 
-from gemdat.orientations import Orientations
+if TYPE_CHECKING:
+    from gemdat.orientations import Orientations
 
 
 def autocorrelation(

--- a/src/gemdat/plots/matplotlib/_bond_length_distribution.py
+++ b/src/gemdat/plots/matplotlib/_bond_length_distribution.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import matplotlib.pyplot as plt
 
-from gemdat.orientations import Orientations
-
 from .._shared import _fit_skewnorm_to_hist, _orientations_to_histogram
+
+if TYPE_CHECKING:
+    from gemdat.orientations import Orientations
 
 
 def bond_length_distribution(*, orientations: Orientations, bins: int = 50) -> plt.Figure:

--- a/src/gemdat/plots/matplotlib/_displacement_histogram.py
+++ b/src/gemdat/plots/matplotlib/_displacement_histogram.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import matplotlib.pyplot as plt
 
-from gemdat.trajectory import Trajectory
+if TYPE_CHECKING:
+    from gemdat.trajectory import Trajectory
 
 
 def displacement_histogram(trajectory: Trajectory) -> plt.Figure:

--- a/src/gemdat/plots/matplotlib/_displacement_per_atom.py
+++ b/src/gemdat/plots/matplotlib/_displacement_per_atom.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import matplotlib.pyplot as plt
 
-from gemdat.trajectory import Trajectory
+if TYPE_CHECKING:
+    from gemdat.trajectory import Trajectory
 
 
 def displacement_per_atom(*, trajectory: Trajectory) -> plt.Figure:

--- a/src/gemdat/plots/matplotlib/_displacement_per_element.py
+++ b/src/gemdat/plots/matplotlib/_displacement_per_element.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import matplotlib.pyplot as plt
 
 from gemdat.plots._shared import _mean_displacements_per_element
-from gemdat.trajectory import Trajectory
+
+if TYPE_CHECKING:
+    from gemdat.trajectory import Trajectory
 
 
 def displacement_per_element(*, trajectory: Trajectory) -> plt.Figure:

--- a/src/gemdat/plots/matplotlib/_energy_along_path.py
+++ b/src/gemdat/plots/matplotlib/_energy_along_path.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import matplotlib.pyplot as plt
 from pymatgen.core import Structure
 
-from gemdat.path import Pathway
+if TYPE_CHECKING:
+    from gemdat.path import Pathway
 
 
 def energy_along_path(

--- a/src/gemdat/plots/matplotlib/_frequency_vs_occurence.py
+++ b/src/gemdat/plots/matplotlib/_frequency_vs_occurence.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import matplotlib.pyplot as plt
 import numpy as np
 
 from gemdat.simulation_metrics import SimulationMetrics
-from gemdat.trajectory import Trajectory
+
+if TYPE_CHECKING:
+    from gemdat.trajectory import Trajectory
 
 
 def frequency_vs_occurence(*, trajectory: Trajectory) -> plt.Figure:

--- a/src/gemdat/plots/matplotlib/_msd_per_element.py
+++ b/src/gemdat/plots/matplotlib/_msd_per_element.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import matplotlib.pyplot as plt
 import numpy as np
 
-from gemdat.trajectory import Trajectory
+if TYPE_CHECKING:
+    from gemdat.trajectory import Trajectory
 
 
 def msd_per_element(

--- a/src/gemdat/plots/matplotlib/_rectilinear.py
+++ b/src/gemdat/plots/matplotlib/_rectilinear.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import matplotlib.pyplot as plt
 import numpy as np
 
-from gemdat.orientations import (
-    Orientations,
-    calculate_spherical_areas,
-)
+if TYPE_CHECKING:
+    from gemdat.orientations import Orientations
 
 
 def rectilinear(
@@ -32,6 +32,8 @@ def rectilinear(
     fig : matplotlib.figure.Figure
         Output figure
     """
+    from gemdat.orientations import calculate_spherical_areas
+
     az, el, _ = orientations.vectors_spherical.T
     az = az.flatten()
     el = el.flatten()

--- a/src/gemdat/plots/matplotlib/_vibrational_amplitudes.py
+++ b/src/gemdat/plots/matplotlib/_vibrational_amplitudes.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import stats
 
 from gemdat.simulation_metrics import SimulationMetrics
-from gemdat.trajectory import Trajectory
+
+if TYPE_CHECKING:
+    from gemdat.trajectory import Trajectory
 
 
 def vibrational_amplitudes(*, trajectory: Trajectory) -> plt.Figure:

--- a/src/gemdat/plots/plotly/_autocorrelation.py
+++ b/src/gemdat/plots/plotly/_autocorrelation.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import plotly.graph_objects as go
 
-from gemdat.orientations import Orientations
+if TYPE_CHECKING:
+    from gemdat.orientations import Orientations
 
 
 def autocorrelation(

--- a/src/gemdat/plots/plotly/_bond_length_distribution.py
+++ b/src/gemdat/plots/plotly/_bond_length_distribution.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import plotly.express as px
 import plotly.graph_objects as go
 
-from gemdat.orientations import Orientations
-
 from .._shared import _fit_skewnorm_to_hist, _orientations_to_histogram
+
+if TYPE_CHECKING:
+    from gemdat.orientations import Orientations
 
 
 def bond_length_distribution(*, orientations: Orientations, bins: int = 50) -> go.Figure:

--- a/src/gemdat/plots/plotly/_displacement_histogram.py
+++ b/src/gemdat/plots/plotly/_displacement_histogram.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
 
-from gemdat.trajectory import Trajectory
+if TYPE_CHECKING:
+    from gemdat.trajectory import Trajectory
 
 
 def _trajectory_to_dataframe(trajectory: Trajectory) -> pd.DataFrame:

--- a/src/gemdat/plots/plotly/_displacement_per_atom.py
+++ b/src/gemdat/plots/plotly/_displacement_per_atom.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import plotly.graph_objects as go
 
-from gemdat.trajectory import Trajectory
+if TYPE_CHECKING:
+    from gemdat.trajectory import Trajectory
 
 
 def displacement_per_atom(*, trajectory: Trajectory) -> go.Figure:

--- a/src/gemdat/plots/plotly/_displacement_per_element.py
+++ b/src/gemdat/plots/plotly/_displacement_per_element.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import plotly.graph_objects as go
 
 from gemdat.plots._shared import _mean_displacements_per_element
-from gemdat.trajectory import Trajectory
+
+if TYPE_CHECKING:
+    from gemdat.trajectory import Trajectory
 
 
 def displacement_per_element(*, trajectory: Trajectory) -> go.Figure:

--- a/src/gemdat/plots/plotly/_energy_along_path.py
+++ b/src/gemdat/plots/plotly/_energy_along_path.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 from itertools import pairwise
+from typing import TYPE_CHECKING
 
 import numpy as np
 import plotly.graph_objects as go
 from pymatgen.core import Structure
 
-from gemdat.path import Pathway
+if TYPE_CHECKING:
+    from gemdat.path import Pathway
 
 
 def energy_along_path(

--- a/src/gemdat/plots/plotly/_frequency_vs_occurence.py
+++ b/src/gemdat/plots/plotly/_frequency_vs_occurence.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import plotly.graph_objects as go
 
 from gemdat.simulation_metrics import SimulationMetrics
-from gemdat.trajectory import Trajectory
+
+if TYPE_CHECKING:
+    from gemdat.trajectory import Trajectory
 
 
 def frequency_vs_occurence(*, trajectory: Trajectory) -> go.Figure:

--- a/src/gemdat/plots/plotly/_msd_per_element.py
+++ b/src/gemdat/plots/plotly/_msd_per_element.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import plotly.graph_objects as go
 
-from gemdat.trajectory import Trajectory
+if TYPE_CHECKING:
+    from gemdat.trajectory import Trajectory
 
 
 def msd_per_element(*, trajectory: Trajectory) -> go.Figure:

--- a/src/gemdat/plots/plotly/_rectilinear.py
+++ b/src/gemdat/plots/plotly/_rectilinear.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import plotly.graph_objects as go
 
-from gemdat.orientations import (
-    Orientations,
-    calculate_spherical_areas,
-)
+if TYPE_CHECKING:
+    from gemdat.orientations import Orientations
 
 
 def rectilinear(
@@ -32,6 +32,8 @@ def rectilinear(
     fig : plotly.graph_objects.Figure
         Output figure
     """
+    from gemdat.orientations import calculate_spherical_areas
+
     az, el, _ = orientations.vectors_spherical.T
     az = az.flatten()
     el = el.flatten()

--- a/src/gemdat/plots/plotly/_vibrational_amplitudes.py
+++ b/src/gemdat/plots/plotly/_vibrational_amplitudes.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pandas as pd
 import plotly.express as px
@@ -7,7 +9,9 @@ import plotly.graph_objects as go
 from scipy import stats
 
 from gemdat.simulation_metrics import SimulationMetrics
-from gemdat.trajectory import Trajectory
+
+if TYPE_CHECKING:
+    from gemdat.trajectory import Trajectory
 
 
 def vibrational_amplitudes(

--- a/src/gemdat/rdf.py
+++ b/src/gemdat/rdf.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING
 import numpy as np
 from rich.progress import track
 
+from ._plot_backend import plot_backend
+
 if TYPE_CHECKING:
     from pymatgen.core import Structure
 
@@ -89,21 +91,19 @@ class RDFData:
     symbol: str
     state: str
 
-    def plot(self, **kwargs):
+    @plot_backend
+    def plot(self, *, module, **kwargs):
         """See [gemdat.plots.radial_distribution][] for more info."""
-        from gemdat import plots
-
-        return plots.radial_distribution(rdfs=[self], **kwargs)
+        return module.radial_distribution(rdfs=[self], **kwargs)
 
 
 class RDFCollection(list[RDFData]):
     """Collection to store group of radial distribution data."""
 
-    def plot(self, **kwargs):
+    @plot_backend
+    def plot(self, *, module, **kwargs):
         """See [gemdat.plots.radial_distribution][] for more info."""
-        from gemdat import plots
-
-        return plots.radial_distribution(rdfs=self, **kwargs)
+        return module.radial_distribution(rdfs=self, **kwargs)
 
 
 def radial_distribution(

--- a/src/gemdat/shape.py
+++ b/src/gemdat/shape.py
@@ -7,6 +7,7 @@ import numpy as np
 from pymatgen.core import Lattice, PeriodicSite, Structure
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 
+from ._plot_backend import plot_backend
 from .trajectory import Trajectory
 from .utils import warn_lattice_not_close
 
@@ -73,11 +74,10 @@ class ShapeData:
         centroid = np.mean(self.coords, axis=0)
         return centroid
 
-    def plot(self, **kwargs):
+    @plot_backend
+    def plot(self, *, module, **kwargs):
         """See [gemdat.plots.shape][] for more info."""
-        from gemdat import plots
-
-        return plots.shape(shape=self, **kwargs)
+        return module.shape(shape=self, **kwargs)
 
 
 class ShapeAnalyzer:

--- a/src/gemdat/simulation_metrics.py
+++ b/src/gemdat/simulation_metrics.py
@@ -14,7 +14,7 @@ from .caching import weak_lru_cache
 from .utils import meanfreq
 
 if typing.TYPE_CHECKING:
-    from gemdat.trajectory import Trajectory
+    from trajectory import Trajectory
 
 
 class SimulationMetrics:

--- a/src/gemdat/trajectory.py
+++ b/src/gemdat/trajectory.py
@@ -16,6 +16,8 @@ from pymatgen.core import Lattice
 from pymatgen.core.trajectory import Trajectory as PymatgenTrajectory
 from pymatgen.io import vasp
 
+from ._plot_backend import plot_backend
+
 if TYPE_CHECKING:
     from pymatgen.core import Structure
 
@@ -520,38 +522,32 @@ class Trajectory(PymatgenTrajectory):
             site_inner_fraction=site_inner_fraction,
         )
 
-    def plot_displacement_per_atom(self, **kwargs):
+    @plot_backend
+    def plot_displacement_per_atom(self, *, module, **kwargs):
         """See [gemdat.plots.displacement_per_atom][] for more info."""
-        from gemdat import plots
+        return module.displacement_per_atom(trajectory=self, **kwargs)
 
-        return plots.displacement_per_atom(trajectory=self, **kwargs)
-
-    def plot_displacement_per_element(self, **kwargs):
+    @plot_backend
+    def plot_displacement_per_element(self, *, module, **kwargs):
         """See [gemdat.plots.displacement_per_element][] for more info."""
-        from gemdat import plots
+        return module.displacement_per_element(trajectory=self, **kwargs)
 
-        return plots.displacement_per_element(trajectory=self, **kwargs)
-
-    def plot_msd_per_element(self, **kwargs):
+    @plot_backend
+    def plot_msd_per_element(self, *, module, **kwargs):
         """See [gemdat.plots.msd_per_element][] for more info."""
-        from gemdat import plots
+        return module.msd_per_element(trajectory=self, **kwargs)
 
-        return plots.msd_per_element(trajectory=self, **kwargs)
-
-    def plot_displacement_histogram(self, **kwargs):
+    @plot_backend
+    def plot_displacement_histogram(self, *, module, **kwargs):
         """See [gemdat.plots.displacement_histogram][] for more info."""
-        from gemdat import plots
+        return module.displacement_histogram(trajectory=self, **kwargs)
 
-        return plots.displacement_histogram(trajectory=self, **kwargs)
-
-    def plot_frequency_vs_occurence(self, **kwargs):
+    @plot_backend
+    def plot_frequency_vs_occurence(self, *, module, **kwargs):
         """See [gemdat.plots.frequency_vs_occurence][] for more info."""
-        from gemdat import plots
+        return module.frequency_vs_occurence(trajectory=self, **kwargs)
 
-        return plots.frequency_vs_occurence(trajectory=self, **kwargs)
-
-    def plot_vibrational_amplitudes(self, **kwargs):
+    @plot_backend
+    def plot_vibrational_amplitudes(self, *, module, **kwargs):
         """See [gemdat.plots.vibrational_amplitudes][] for more info."""
-        from gemdat import plots
-
-        return plots.vibrational_amplitudes(trajectory=self, **kwargs)
+        return module.vibrational_amplitudes(trajectory=self, **kwargs)

--- a/src/gemdat/transitions.py
+++ b/src/gemdat/transitions.py
@@ -21,6 +21,7 @@ if typing.TYPE_CHECKING:
     from gemdat.rdf import RDFCollection
     from gemdat.trajectory import Trajectory
 
+
 NOSITE = -1
 
 

--- a/src/gemdat/volume.py
+++ b/src/gemdat/volume.py
@@ -15,6 +15,7 @@ from scipy.constants import physical_constants
 from skimage.feature import blob_dog
 from skimage.measure import regionprops
 
+from ._plot_backend import plot_backend
 from .segmentation import watershed_pbc
 
 if TYPE_CHECKING:
@@ -377,11 +378,10 @@ class Volume:
             lattice=self.lattice,
         )
 
-    def plot_3d(self, **kwargs):
+    @plot_backend
+    def plot_3d(self, *, module, **kwargs):
         """See [gemdat.plots.plot_3d][] for more info."""
-        from gemdat import plots
-
-        return plots.plot_3d(volume=self, **kwargs)
+        return module.plot_3d(volume=self, **kwargs)
 
 
 class FreeEnergyVolume(Volume):

--- a/tests/integration/plot_mpl_test.py
+++ b/tests/integration/plot_mpl_test.py
@@ -4,61 +4,62 @@ import numpy as np
 from helpers import image_comparison2
 
 from gemdat.io import load_known_material
-from gemdat.plots import matplotlib as plots
+
+BACKEND = 'matplotlib'
 
 
 @image_comparison2(baseline_images=['displacement_per_element'])
 def test_displacement_per_element(vasp_traj):
-    plots.displacement_per_element(trajectory=vasp_traj)
+    vasp_traj.plot_displacement_per_element(backend=BACKEND)
 
 
 @image_comparison2(baseline_images=['displacement_per_atom'])
 def test_displacement_per_atom(vasp_traj):
     diff_trajectory = vasp_traj.filter('Li')
-    plots.displacement_per_atom(trajectory=diff_trajectory)
+    diff_trajectory.plot_displacement_per_atom(backend=BACKEND)
 
 
 @image_comparison2(baseline_images=['displacement_histogram'])
 def test_displacement_histogram(vasp_traj):
     diff_trajectory = vasp_traj.filter('Li')
-    plots.displacement_histogram(trajectory=diff_trajectory)
+    diff_trajectory.plot_displacement_histogram(backend=BACKEND)
 
 
 @image_comparison2(baseline_images=['frequency_vs_occurence'])
 def test_frequency_vs_occurence(vasp_traj):
     diff_traj = vasp_traj.filter('Li')
-    plots.frequency_vs_occurence(trajectory=diff_traj)
+    diff_traj.plot_frequency_vs_occurence(backend=BACKEND)
 
 
 @image_comparison2(baseline_images=['vibrational_amplitudes'])
 def test_vibrational_amplitudes(vasp_traj):
     diff_traj = vasp_traj.filter('Li')
-    plots.vibrational_amplitudes(trajectory=diff_traj)
+    diff_traj.plot_vibrational_amplitudes(backend=BACKEND)
 
 
 @image_comparison2(baseline_images=['jumps_vs_distance'])
 def test_jumps_vs_distance(vasp_jumps):
-    plots.jumps_vs_distance(jumps=vasp_jumps)
+    vasp_jumps.plot_jumps_vs_distance(backend=BACKEND)
 
 
 @image_comparison2(baseline_images=['jumps_vs_time'])
 def test_jumps_vs_time(vasp_jumps):
-    plots.jumps_vs_time(jumps=vasp_jumps)
+    vasp_jumps.plot_jumps_vs_time(backend=BACKEND)
 
 
 @image_comparison2(baseline_images=['collective_jumps'])
 def test_collective_jumps(vasp_jumps):
-    plots.collective_jumps(jumps=vasp_jumps)
+    vasp_jumps.plot_collective_jumps(backend=BACKEND)
 
 
 @image_comparison2(baseline_images=['jumps_3d'])
 def test_jumps_3d(vasp_jumps):
-    plots.jumps_3d(jumps=vasp_jumps)
+    vasp_jumps.plot_jumps_3d(backend=BACKEND)
 
 
 @image_comparison2(baseline_images=['jumps_3d_animation'])
 def test_jumps_3d_animation(vasp_jumps):
-    plots.jumps_3d_animation(jumps=vasp_jumps, t_start=1000, t_stop=1001)
+    vasp_jumps.plot_jumps_3d_animation(backend=BACKEND, t_start=1000, t_stop=1001)
 
 
 @image_comparison2(
@@ -71,25 +72,26 @@ def test_jumps_3d_animation(vasp_jumps):
 def test_radial_distribution(vasp_rdf_data):
     assert len(vasp_rdf_data) == 3
     for rdfs in vasp_rdf_data.values():
-        plots.radial_distribution(rdfs)
+        rdfs.plot(backend=BACKEND)
 
 
 @image_comparison2(baseline_images=['shape'])
 def test_shape(vasp_shape_data):
     assert len(vasp_shape_data) == 1
     for shape in vasp_shape_data:
-        plots.shape(shape)
+        shape.plot(backend=BACKEND)
 
 
 @image_comparison2(baseline_images=['msd_per_element'])
 def test_msd_per_element(vasp_traj):
-    plots.msd_per_element(trajectory=vasp_traj[-500:])
+    traj = vasp_traj[-500:]
+    traj.plot_msd_per_element(backend=BACKEND)
 
 
 @image_comparison2(baseline_images=['energy_along_path'])
 def test_energy_along_path(vasp_path):
     structure = load_known_material('argyrodite')
-    plots.energy_along_path(path=vasp_path, structure=structure)
+    vasp_path.plot_energy_along_path(backend=BACKEND, structure=structure)
 
 
 @image_comparison2(baseline_images=['rectilinear'])
@@ -103,14 +105,14 @@ def test_rectilinear(vasp_orientations):
     )
 
     orientations = vasp_orientations.normalize().transform(matrix=matrix)
-    plots.rectilinear(orientations=orientations, normalize_histo=False)
+    orientations.plot_rectilinear(backend=BACKEND, normalize_histo=False)
 
 
 @image_comparison2(baseline_images=['bond_length_distribution'])
 def test_bond_length_distribution(vasp_orientations):
-    plots.bond_length_distribution(orientations=vasp_orientations, bins=50)
+    vasp_orientations.plot_bond_length_distribution(backend=BACKEND, bins=50)
 
 
 @image_comparison2(baseline_images=['autocorrelation'])
 def test_autocorrelation(vasp_orientations):
-    plots.autocorrelation(orientations=vasp_orientations)
+    vasp_orientations.plot_autocorrelation(backend=BACKEND)

--- a/tests/integration/plot_plotly_test.py
+++ b/tests/integration/plot_plotly_test.py
@@ -5,63 +5,64 @@ import pytest
 from helpers import assert_figures_similar
 
 from gemdat.io import load_known_material
-from gemdat.plots import plotly as plots
+
+BACKEND = 'plotly'
 
 
 def test_displacement_per_element(vasp_traj):
-    fig = plots.displacement_per_element(trajectory=vasp_traj)
+    fig = vasp_traj.plot_displacement_per_element(backend=BACKEND)
 
     assert_figures_similar(fig, name='displacement_per_element', rms=0.5)
 
 
 def test_displacement_per_atom(vasp_traj):
     diff_trajectory = vasp_traj.filter('Li')
-    fig = plots.displacement_per_atom(trajectory=diff_trajectory)
+    fig = diff_trajectory.plot_displacement_per_atom(backend=BACKEND)
 
     assert_figures_similar(fig, name='displacement_per_atom', rms=0.5)
 
 
 def test_displacement_histogram(vasp_traj):
     diff_trajectory = vasp_traj.filter('Li')
-    fig = plots.displacement_histogram(trajectory=diff_trajectory)
+    fig = diff_trajectory.plot_displacement_histogram(backend=BACKEND)
 
     assert_figures_similar(fig, name='displacement_histogram', rms=0.5)
 
 
 def test_frequency_vs_occurence(vasp_traj):
     diff_traj = vasp_traj.filter('Li')
-    fig = plots.frequency_vs_occurence(trajectory=diff_traj)
+    fig = diff_traj.plot_frequency_vs_occurence(backend=BACKEND)
 
     assert_figures_similar(fig, name='frequency_vs_occurence', rms=0.5)
 
 
 def test_vibrational_amplitudes(vasp_traj):
     diff_traj = vasp_traj.filter('Li')
-    fig = plots.vibrational_amplitudes(trajectory=diff_traj)
+    fig = diff_traj.plot_vibrational_amplitudes(backend=BACKEND)
 
     assert_figures_similar(fig, name='vibrational_amplitudes', rms=0.5)
 
 
 def test_jumps_vs_distance(vasp_jumps):
-    fig = plots.jumps_vs_distance(jumps=vasp_jumps)
+    fig = vasp_jumps.plot_jumps_vs_distance(backend=BACKEND)
 
     assert_figures_similar(fig, name='jumps_vs_distance', rms=0.5)
 
 
 def test_jumps_vs_time(vasp_jumps):
-    fig = plots.jumps_vs_time(jumps=vasp_jumps)
+    fig = vasp_jumps.plot_jumps_vs_time(backend=BACKEND)
 
     assert_figures_similar(fig, name='jumps_vs_time', rms=0.5)
 
 
 def test_collective_jumps(vasp_jumps):
-    fig = plots.collective_jumps(jumps=vasp_jumps)
+    fig = vasp_jumps.plot_collective_jumps(backend=BACKEND)
 
     assert_figures_similar(fig, name='collective_jumps', rms=0.5)
 
 
 def test_jumps_3d(vasp_jumps):
-    fig = plots.jumps_3d(jumps=vasp_jumps)
+    fig = vasp_jumps.plot_jumps_3d(backend=BACKEND)
 
     assert_figures_similar(fig, name='jumps_3d', rms=0.5)
 
@@ -69,7 +70,7 @@ def test_jumps_3d(vasp_jumps):
 def test_radial_distribution(vasp_rdf_data):
     assert len(vasp_rdf_data) == 3
     for i, rdfs in enumerate(vasp_rdf_data.values()):
-        fig = plots.radial_distribution(rdfs)
+        fig = rdfs.plot(backend=BACKEND)
 
         assert_figures_similar(fig, name=f'radial_distribution_{i}', rms=0.5)
 
@@ -78,20 +79,21 @@ def test_radial_distribution(vasp_rdf_data):
 def test_shape(vasp_shape_data):
     assert len(vasp_shape_data) == 1
     for i, shape in vasp_shape_data:
-        fig = plots.shape(shape)
+        fig = shape.plot(backend=BACKEND)
 
         assert_figures_similar(fig, name='shape_{i}', rms=0.5)
 
 
 def test_msd_per_element(vasp_traj):
-    fig = plots.msd_per_element(trajectory=vasp_traj[-500:])
+    vasp_traj = vasp_traj[-500:]
+    fig = vasp_traj.plot_msd_per_element(backend=BACKEND)
 
     assert_figures_similar(fig, name='msd_per_element', rms=0.5)
 
 
 def test_energy_along_path(vasp_path):
     structure = load_known_material('argyrodite')
-    fig = plots.energy_along_path(path=vasp_path, structure=structure)
+    fig = vasp_path.plot_energy_along_path(backend=BACKEND, structure=structure)
 
     assert_figures_similar(fig, name='energy_along_path', rms=0.5)
 
@@ -106,18 +108,18 @@ def test_rectilinear(vasp_orientations):
     )
 
     orientations = vasp_orientations.normalize().transform(matrix=matrix)
-    fig = plots.rectilinear(orientations=orientations, normalize_histo=False)
+    fig = orientations.plot_rectilinear(backend=BACKEND, normalize_histo=False)
 
     assert_figures_similar(fig, name='rectilinear', rms=0.5)
 
 
 def test_bond_length_distribution(vasp_orientations):
-    fig = plots.bond_length_distribution(orientations=vasp_orientations, bins=50)
+    fig = vasp_orientations.plot_bond_length_distribution(backend=BACKEND, bins=50)
 
     assert_figures_similar(fig, name='bond_length_distribution', rms=0.5)
 
 
 def test_autocorrelation(vasp_orientations):
-    fig = plots.autocorrelation(orientations=vasp_orientations)
+    fig = vasp_orientations.plot_autocorrelation(backend=BACKEND)
 
     assert_figures_similar(fig, name='autocorrelation', rms=0.5)


### PR DESCRIPTION
This PR adds a user option to choose the backend for plotting.

The implementation is based on a decorator that strips the backend from the argument list and passes the plotting module (plots.matplotlib or plots.plotly) to the plotting method.

```python
trajectory.plot_displacement_per_atom()  # default backend
trajectory.plot_displacement_per_atom(backend='matplotlib')
trajectory.plot_displacement_per_atom(backend='plotly')
```

Closes #319 

### Todo

- [x] Update tests to make use of the decorator