### PR TITLE
Fix crash in `Transitions.occupancy` if input sites are disordered

### DIFF
--- a/src/gemdat/transitions.py
+++ b/src/gemdat/transitions.py
@@ -275,7 +275,22 @@ class Transitions:
             labels=sites.labels,
         )
 
-    def atom_locations(self):
+    def occupancy_by_site_type(self) -> dict[str, float]:
+        """Calculate average occupancy per a type of site.
+
+        Returns
+        -------
+        occupancy : dict[str, float]
+            Return dict with average occupancy per site type
+        """
+        compositions_by_label = defaultdict(list)
+
+        for site in self.occupancy():
+            compositions_by_label[site.label].append(site.species.num_atoms)
+
+        return {k: sum(v) / len(v) for k, v in compositions_by_label.items()}
+
+    def atom_locations(self) -> dict[str, float]:
         """Calculate fraction of time atoms spent at a type of site.
 
         Returns
@@ -283,19 +298,13 @@ class Transitions:
         dict[str, float]
             Return dict with the fraction of time atoms spent at a site
         """
-        multiplier = len(self.sites) / self.n_floating
-
+        n = self.n_floating
         compositions_by_label = defaultdict(list)
 
         for site in self.occupancy():
             compositions_by_label[site.label].append(site.species.num_atoms)
 
-        ret = {}
-
-        for k, v in compositions_by_label.items():
-            ret[k] = (sum(v) / len(v)) * multiplier
-
-        return ret
+        return {k: sum(v) / n for k, v in compositions_by_label.items()}
 
     def split(self, n_parts: int = 10) -> list[Transitions]:
         """Split data into equal parts in time for statistics.

--- a/src/gemdat/transitions.py
+++ b/src/gemdat/transitions.py
@@ -252,7 +252,10 @@ class Transitions:
         counts = counts / len(states)
         occupancies = dict(zip(unq, counts))
 
-        species = [{site.specie.name: occupancies.get(i, 0)} for i, site in enumerate(sites)]
+        species = [
+            {site.species.elements[0].name: occupancies.get(i, 0)}
+            for i, site in enumerate(sites)
+        ]
 
         return Structure(
             lattice=sites.lattice,

--- a/src/gemdat/transitions.py
+++ b/src/gemdat/transitions.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import typing
 from collections import defaultdict
 from itertools import pairwise
+from warnings import warn
 
 import numpy as np
 import pandas as pd
@@ -67,6 +68,15 @@ class Transitions:
         inner_states : np.ndarray
             Input states for inner sites
         """
+        if not (sites.is_ordered):
+            warn(
+                'Input `sites` are disordered! '
+                'Although the code may work, it was written under the assumption '
+                'that an ordered structure would be passed. '
+                'See https://github.com/GEMDAT-repos/GEMDAT/issues/339 for more information.',
+                stacklevel=2,
+            )
+
         self.sites = sites
         self.trajectory = trajectory
         self.diff_trajectory = diff_trajectory

--- a/tests/integration/transitions_test.py
+++ b/tests/integration/transitions_test.py
@@ -133,6 +133,10 @@ class TestTransitions:  # type: ignore
             35.43733333333334,
         ]
 
+    def test_occupancy_by_site_type(self, vasp_transitions):
+        occ = vasp_transitions.occupancy_by_site_type()
+        assert occ == {'48h': 0.3806277777777776}
+
     def test_atom_locations(self, vasp_transitions):
         dct = vasp_transitions.atom_locations()
         assert dct == {'48h': 0.7612555555555552}


### PR DESCRIPTION
This PR adds a  work-around when `Transitions.occupancy` is called, but the input sites are disordered. Disordered jump sites technically do not make sense, but the code only works with the coordinates anyway.

Closes #339