### PR TITLE
Add warning if there are no species in range of site

### DIFF
--- a/src/gemdat/transitions.py
+++ b/src/gemdat/transitions.py
@@ -534,7 +534,7 @@ def _calculate_atom_states(
         site_index = periodic_tree.search_tree(cart_coords, radius * site_inner_fraction)
 
         if site_index.size == 0:
-            warn(f'No floating species in range of {label} ({radius=}', stacklevel=2)
+            warn(f'No floating species in range of {label} ({radius=})', stacklevel=2)
             continue
 
         siteno, index = site_index.T


### PR DESCRIPTION
This PR fixes a crash if no near atoms were found in the periodic search tree. It now checks for a null result and adds a warning. I also refactored the code slightly.

Closes #352