### PR TITLE
Raise error when disordered structure is passed to `Transitions`

### DIFF
--- a/src/gemdat/trajectory.py
+++ b/src/gemdat/trajectory.py
@@ -33,7 +33,7 @@ SP_NAME = re.compile(r'([a-zA-Z]+)')
 
 
 def _lengths(vectors: np.ndarray, lattice: Lattice) -> np.ndarray:
-    """Calculate vector lengths using the metric tensor (Dunitz 1078, p227).
+    """Calculate vector lengths using the metric tensor (Dunitz 1978, p227).
 
     Parameters
     ----------

--- a/src/gemdat/transitions.py
+++ b/src/gemdat/transitions.py
@@ -42,6 +42,7 @@ class Transitions:
 
     DISORDER_ERROR_MSG = (
         'Input `sites` are disordered! '
+        'The analysis does not work with disordered structures. '
         'Remove disorder and partial occupancies or try '
         '`gemdat.utils.remove_disorder_from_structure(). '
         'See https://github.com/GEMDAT-repos/GEMDAT/issues/339 for more information.'

--- a/src/gemdat/transitions.py
+++ b/src/gemdat/transitions.py
@@ -40,6 +40,13 @@ class Transitions:
         Assingn NOSITE if the atom is in transition
     """
 
+    DISORDER_ERROR_MSG = (
+        'Input `sites` are disordered! '
+        'Remove disorder and partial occupancies or try '
+        '`gemdat.utils.remove_disorder_from_structure(). '
+        'See https://github.com/GEMDAT-repos/GEMDAT/issues/339 for more information.'
+    )
+
     def __init__(
         self,
         *,
@@ -72,20 +79,7 @@ class Transitions:
             Change partial occupancies in the disordered sites and set them to 1.
         """
         if not (sites.is_ordered):
-            warn(
-                'Input `sites` are disordered! '
-                'Although the code may work, it was written under the assumption '
-                'that an ordered structure would be passed. '
-                'Use `set_partial_occupancies_to_1=True` to set all occupancies to 1.'
-                'See https://github.com/GEMDAT-repos/GEMDAT/issues/339 for more information.',
-                stacklevel=2,
-            )
-
-        if set_partial_occupancies_to_1:
-            for idx, site in enumerate(sites):
-                if site.is_ordered:
-                    continue
-                sites.replace(idx=idx, species=site.species.elements[0], label=site.label)
+            raise ValueError(self.DISORDER_ERROR_MSG)
 
         self.sites = sites
         self.trajectory = trajectory
@@ -125,6 +119,9 @@ class Transitions:
         -------
         transitions: Transitions
         """
+        if not (sites.is_ordered):
+            raise ValueError(cls.DISORDER_ERROR_MSG)
+
         diff_trajectory = trajectory.filter(floating_specie)
 
         if site_radius is None:

--- a/src/gemdat/transitions.py
+++ b/src/gemdat/transitions.py
@@ -57,7 +57,6 @@ class Transitions:
         events: pd.DataFrame,
         states: np.ndarray,
         inner_states: np.ndarray,
-        set_partial_occupancies_to_1: bool = False,
     ):
         """Store event data for jumps and transitions between sites.
 
@@ -76,8 +75,6 @@ class Transitions:
             Input states
         inner_states : np.ndarray
             Input states for inner sites
-        set_partial_occupancies_to_1 : bool
-            Change partial occupancies in the disordered sites and set them to 1.
         """
         if not (sites.is_ordered):
             raise ValueError(self.DISORDER_ERROR_MSG)

--- a/src/gemdat/utils.py
+++ b/src/gemdat/utils.py
@@ -305,3 +305,27 @@ def fft_autocorrelation(coords: np.ndarray) -> np.ndarray:
     autocorrelation = autocorrelation / autocorrelation[:, 0, np.newaxis]
 
     return autocorrelation
+
+
+def remove_disorder_from_structure(structure: Structure) -> Structure:
+    """Attempts to remove disorder and partial occupancies from input
+    structure.
+
+    Parameters
+    ----------
+    structure : Structure
+        Input structure
+
+    Returns
+    -------
+    new_structure : Structure
+        Output structure with disorder removed
+    """
+    new_structure = structure.copy()
+
+    for idx, site in enumerate(new_structure):
+        if site.is_ordered:
+            continue
+        new_structure.replace(idx=idx, species=site.species.elements[0], label=site.label)
+
+    return new_structure

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -3,8 +3,16 @@ from __future__ import annotations
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_equal
+from pymatgen.core import Structure
 
-from gemdat.utils import bfill, cartesian_to_spherical, ffill, integer_remap, meanfreq
+from gemdat.utils import (
+    bfill,
+    cartesian_to_spherical,
+    ffill,
+    integer_remap,
+    meanfreq,
+    remove_disorder_from_structure,
+)
 
 
 @pytest.fixture
@@ -132,3 +140,18 @@ def test_cartesian_to_spherical():
         ]
     )
     assert_allclose(ret, expected, rtol=1e-5)
+
+
+def test_remove_disorder_from_structure():
+    structure = Structure(
+        lattice=np.eye(3) * 10,
+        coords=[(0, 0, 0), (0.5, 0.5, 0.5)],
+        species=[{'Si': 0.5, 'Ge': 0.5}, {'Ge': 0.5}],
+        labels=['A', 'B'],
+    )
+    assert structure.is_ordered
+
+    new_structure = remove_disorder_from_structure(structure)
+    assert new_structure.is_ordered
+    assert len(new_structure) == 2
+    assert new_structure.labels == structure.labels

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -149,7 +149,7 @@ def test_remove_disorder_from_structure():
         species=[{'Si': 0.5, 'Ge': 0.5}, {'Ge': 0.5}],
         labels=['A', 'B'],
     )
-    assert structure.is_ordered
+    assert not structure.is_ordered
 
     new_structure = remove_disorder_from_structure(structure)
     assert new_structure.is_ordered


### PR DESCRIPTION
This PR changes how disordered species are handled by `Transitions`. It now raises an error, because the analysis does not work with disordered species. I also added this `Transitions.from_trajectory`), so it now breaks at the earliest possible stage. I added a function `gemdat.utils.remove_disorder_from_species` to help 'fix' the structure. 

This fixes 2 issues with the current code:

1. The current code updates `sites` in-place. This can give unintended side effects
2. There is better separation of concerns. This changes allows the user to inspect the `sites` before using the `Transitions` code. This prevents unwanted changes to the structure and places control for making sure the structure is what they wanted with the users.

Usage:

```python
from gemdat.utils import remove_disorder_from_structure

new_structure = remove_disorder_from_structure(structure)
```

Closes #343 