### PR TITLE
Update pymatgen

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -19,8 +19,8 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.12'
     - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,8 +11,8 @@ jobs:
     permissions: write-all
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.11'
 
@@ -54,11 +54,11 @@ jobs:
       id-token: write
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
       with:
         ref: ${{ github.ref_name }}
 
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,7 +24,7 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           submodules: 'true'
 
@@ -33,11 +33,11 @@ jobs:
           tar -C tests/data/short_simulation -xjf tests/data/short_simulation/vasprun.xml.bz2
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: cache-virtualenv
         with:
           path: ${{ env.pythonLocation }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,7 @@ repos:
     rev: v1.7.8
     hooks:
       - id: docformatter
+        additional_dependencies: [charset_normalizer]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.14
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     rev: v0.3.0
     hooks:
       - id: nbcheckorder
-  - repo: https://github.com/myint/docformatter
+  - repo: https://github.com/PyCQA/docformatter
     rev: v1.7.8
     hooks:
       - id: docformatter

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
@@ -20,11 +20,11 @@ repos:
     hooks:
       - id: nbcheckorder
   - repo: https://github.com/myint/docformatter
-    rev: 06907d0
+    rev: v1.7.8
     hooks:
       - id: docformatter
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.0
+    rev: v0.15.14
     hooks:
       - id: ruff
         args: [--fix]
@@ -32,7 +32,7 @@ repos:
       - id: ruff-format
         types_or: [python, pyi, jupyter]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.15.0
+    rev: v2.1.0
     hooks:
       - id: mypy
         additional_dependencies: [matplotlib, MDAnalysis, kinisi, numpy, pymatgen, rich, scikit-image, scipy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
   'kinisi',
   'ase',
   'numpy',
-  'pymatgen >= 2024.1.26, != 2024.2.20, < 2026.3.23',
+  'pymatgen',
   'rich',
   'scikit-image',
   'scipy',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
   'kinisi',
   'ase',
   'numpy',
-  'pymatgen',
+  'pymatgen >= 2024.1.26, != 2024.2.20',
   'rich',
   'scikit-image',
   'scipy',

--- a/src/gemdat/_plot_backend.py
+++ b/src/gemdat/_plot_backend.py
@@ -40,5 +40,4 @@ Returns
 fig : plotly.graph_objects.Figure or matplotlib.figure.Figure depending on backend.
     Output figure
 """
-
     return wrap

--- a/src/gemdat/io.py
+++ b/src/gemdat/io.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import warnings
 from importlib.resources import files
 from pathlib import Path
@@ -86,6 +87,11 @@ def load_known_material(
 
     if supercell:
         structure.make_supercell(supercell)
+        # Newer pymatgen suffixes duplicate site labels with _1, _2, ... when
+        # building a supercell. Strip the suffix so symmetry-equivalent sites
+        # keep a shared label, which the jump/transition analysis groups on.
+        for site in structure:
+            site.label = re.sub(r'_\d+$', '', site.label)
 
     return structure
 

--- a/src/gemdat/jumps.py
+++ b/src/gemdat/jumps.py
@@ -234,7 +234,6 @@ class Jumps:
         collective : Collective
             Output class with data on collective jumps
         """
-
         trajectory = self.trajectory
         sites = self.transitions.sites
 
@@ -326,13 +325,14 @@ class Jumps:
 
     @weak_lru_cache()
     def _counter(self) -> Counter[tuple[int, int]]:
-        """Count number of jumps between sites. Keys are site indices.
+        """Count number of jumps between sites.
 
-        Returns
-        -------
-        counter : Counter[tuple[int, int]]
-            Dictionary with site pairs as keys and corresponding
-            number of jumps as dictionary values
+        Keys are site indices.
+                Returns
+                -------
+                counter : Counter[tuple[int, int]]
+                    Dictionary with site pairs as keys and corresponding
+                    number of jumps as dictionary values
         """
         counter = Counter(zip(self.data['start site'], self.data['destination site']))
         return counter

--- a/src/gemdat/orientations.py
+++ b/src/gemdat/orientations.py
@@ -16,9 +16,10 @@ if TYPE_CHECKING:
 
 @dataclass
 class Orientations:
-    """Container for orientational data. It computes trajectories of unit
-    vectors defined as the distance between a central and satellite atoms,
-    meant to track orientation of molecules or clusters.
+    """Container for orientational data.
+
+    It computes trajectories of unit vectors defined as the distance between a central
+    and satellite atoms, meant to track orientation of molecules or clusters.
 
     Parameters
     ----------

--- a/src/gemdat/path.py
+++ b/src/gemdat/path.py
@@ -176,7 +176,6 @@ def free_energy_graph(
     G : nx.Graph
         Graph of free energy
     """
-
     # Define possible movements in 3D space
     movements = np.array([(1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1)])
     if diagonal:
@@ -232,8 +231,10 @@ _PATHFINDING_METHODS = Literal[
 
 
 def calculate_path_difference(path1: list, path2: list) -> float:
-    """Calculate the difference between two paths. This difference is defined
-    as the percentage of sites that are not shared between the two paths.
+    """Calculate the difference between two paths.
+
+    This difference is defined as the percentage of sites that are not shared between
+    the two paths.
 
     Parameters
     ----------
@@ -247,7 +248,6 @@ def calculate_path_difference(path1: list, path2: list) -> float:
     difference : float
         Difference between the two paths
     """
-
     # Find the shortest and longest paths
     shortest, longest = sorted((path1, path2), key=len)
 
@@ -277,7 +277,6 @@ def _paths_too_similar(path: list, list_of_paths: list, min_diff: float) -> bool
     too_similar : bool
         True if the path is too similar to the other paths
     """
-
     for good_path in list_of_paths:
         if calculate_path_difference(path, good_path.sites) < min_diff:
             return True
@@ -437,7 +436,6 @@ def _optimal_path_minmax_energy(
     optimal_path: list
         Optimal path on the graph between start and stop
     """
-
     max_energy = max([F_graph.nodes[node]['energy'] for node in optimal_path])
     minmax_energy = max_energy
     pruned_F_graph = F_graph.copy()

--- a/src/gemdat/plots/matplotlib/_jumps_vs_distance.py
+++ b/src/gemdat/plots/matplotlib/_jumps_vs_distance.py
@@ -18,7 +18,7 @@ def jumps_vs_distance(
     jump_res: float = 0.1,
     n_parts: int = 1,
 ) -> matplotlib.figure.Figure:
-    """Plot jumps vs. distance histogram.
+    """Plot jumps vs distance histogram.
 
     Parameters
     ----------

--- a/src/gemdat/plots/matplotlib/_jumps_vs_time.py
+++ b/src/gemdat/plots/matplotlib/_jumps_vs_time.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 
 def jumps_vs_time(*, jumps: Jumps, binsize: int = 500) -> matplotlib.figure.Figure:
-    """Plot jumps vs. time histogram.
+    """Plot jumps vs time histogram.
 
     Parameters
     ----------
@@ -25,7 +25,6 @@ def jumps_vs_time(*, jumps: Jumps, binsize: int = 500) -> matplotlib.figure.Figu
     fig : matplotlib.figure.Figure
         Output figure
     """
-
     trajectory = jumps.trajectory
 
     n_steps = len(trajectory)

--- a/src/gemdat/plots/matplotlib/_msd_kinisi.py
+++ b/src/gemdat/plots/matplotlib/_msd_kinisi.py
@@ -70,7 +70,6 @@ def msd_kinisi(
     fig : matplotlib.figure.Figure
         Output figure.
     """
-
     if diffusion_analyzer:
         cache_data = diffusion_analyzer
     else:

--- a/src/gemdat/plots/matplotlib/_polar.py
+++ b/src/gemdat/plots/matplotlib/_polar.py
@@ -17,8 +17,9 @@ def polar(
     shape: tuple[int, int] = (90, 360),
     normalize_histo: bool = True,
 ) -> matplotlib.figure.Figure:
-    """Plot a polar projection of a spherical function. This function uses the
-    transformed trajectory.
+    """Plot a polar projection of a spherical function.
+
+    This function uses the transformed trajectory.
 
     Parameters
     ----------

--- a/src/gemdat/plots/matplotlib/_rectilinear.py
+++ b/src/gemdat/plots/matplotlib/_rectilinear.py
@@ -17,8 +17,9 @@ def rectilinear(
     shape: tuple[int, int] = (90, 360),
     normalize_histo: bool = True,
 ) -> matplotlib.figure.Figure:
-    """Plot a rectilinear projection of a spherical function. This function
-    uses the transformed trajectory.
+    """Plot a rectilinear projection of a spherical function.
+
+    This function uses the transformed trajectory.
 
     Parameters
     ----------

--- a/src/gemdat/plots/plotly/_arrhenius.py
+++ b/src/gemdat/plots/plotly/_arrhenius.py
@@ -27,7 +27,6 @@ def arrhenius(*, fit: ArrheniusFit, show_std: bool = True) -> go.Figure:
     fig : plotly.graph_objects.Figure
         Output figure
     """
-
     T = fit.temperatures
     x = 1000.0 / T
     y = np.log(fit.diffusivities)

--- a/src/gemdat/plots/plotly/_displacement_per_atom.py
+++ b/src/gemdat/plots/plotly/_displacement_per_atom.py
@@ -21,7 +21,6 @@ def displacement_per_atom(*, trajectory: Trajectory) -> go.Figure:
     fig : plotly.graph_objects.Figure
         Output figure
     """
-
     fig = go.Figure()
 
     distances = [dist for dist in trajectory.distances_from_base_position()]

--- a/src/gemdat/plots/plotly/_jumps_vs_distance.py
+++ b/src/gemdat/plots/plotly/_jumps_vs_distance.py
@@ -17,7 +17,7 @@ def jumps_vs_distance(
     jump_res: float = 0.1,
     n_parts: int = 1,
 ) -> go.Figure:
-    """Plot jumps vs. distance histogram.
+    """Plot jumps vs distance histogram.
 
     Parameters
     ----------

--- a/src/gemdat/plots/plotly/_jumps_vs_time.py
+++ b/src/gemdat/plots/plotly/_jumps_vs_time.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
 
 def jumps_vs_time(*, jumps: Jumps, bins: int = 8, n_parts: int = 1) -> go.Figure:
-    """Plot jumps vs. distance histogram.
+    """Plot jumps vs distance histogram.
 
     Parameters
     ----------

--- a/src/gemdat/plots/plotly/_polar.py
+++ b/src/gemdat/plots/plotly/_polar.py
@@ -14,8 +14,9 @@ def polar(
     shape: tuple[int, int] = (90, 360),
     normalize_histo: bool = True,
 ) -> go.Figure:
-    """Plot a polar projection of a spherical function. This function uses the
-    transformed trajectory.
+    """Plot a polar projection of a spherical function.
+
+    This function uses the transformed trajectory.
 
     Parameters
     ----------

--- a/src/gemdat/plots/plotly/_rectilinear.py
+++ b/src/gemdat/plots/plotly/_rectilinear.py
@@ -15,8 +15,9 @@ def rectilinear(
     shape: tuple[int, int] = (90, 360),
     normalize_histo: bool = True,
 ) -> go.Figure:
-    """Plot a rectilinear projection of a spherical function. This function
-    uses the transformed trajectory.
+    """Plot a rectilinear projection of a spherical function.
+
+    This function uses the transformed trajectory.
 
     Parameters
     ----------

--- a/src/gemdat/shape.py
+++ b/src/gemdat/shape.py
@@ -318,7 +318,7 @@ class ShapeAnalyzer:
 
     def shift_sites(
         self,
-        vectors: Sequence[None | Sequence[float]],
+        vectors: Sequence[None | Sequence[float] | np.ndarray],
         coords_are_cartesian: bool = True,
     ) -> ShapeAnalyzer:
         """Shift `.unique_sites` by given vectors.

--- a/src/gemdat/trajectory.py
+++ b/src/gemdat/trajectory.py
@@ -24,7 +24,7 @@ from ._plot_backend import plot_backend
 
 if TYPE_CHECKING:
     import scipp as sc
-    from ase.io.trajectory import Trajectory as AseTrajectory
+    from ase.io.trajectory import TrajectoryReader as AseTrajectory
     from kinisi.analyze import DiffusionAnalyzer
     from pymatgen.core import Lattice, Structure
 

--- a/src/gemdat/trajectory.py
+++ b/src/gemdat/trajectory.py
@@ -426,7 +426,6 @@ class Trajectory(PymatgenTrajectory):
         trajectory : Trajectory
             Output trajectory
         """
-
         import MDAnalysis as mda
         from pymatgen.core import Lattice
 
@@ -529,7 +528,6 @@ class Trajectory(PymatgenTrajectory):
         trajectory : gemdat.Trajectory
             A GEMDAT trajectory instance.
         """
-
         from ase.io.trajectory import Trajectory as AseTrajectory
 
         if stride < 1:
@@ -640,7 +638,6 @@ class Trajectory(PymatgenTrajectory):
         ase_traj : ase.io.trajectory.Trajectory
         ASE trajectory opened in read mode.
         """
-
         if stride < 1:
             raise ValueError(f'{stride=} must be >= 1')
 
@@ -796,8 +793,9 @@ class Trajectory(PymatgenTrajectory):
         fixed_species: None | str | Collection[str] = None,
         floating_species: None | str | Collection[str] = None,
     ) -> Trajectory:
-        """Apply drift correction to trajectory. For details see
-        [drift()][gemdat.trajectory.Trajectory.drift].
+        """Apply drift correction to trajectory.
+
+        For details see [drift()][gemdat.trajectory.Trajectory.drift].
 
         If no species are specified, use all species to calculate drift.
 

--- a/src/gemdat/transitions.py
+++ b/src/gemdat/transitions.py
@@ -551,7 +551,6 @@ class SiteRadius:
         site_radius : SiteRadius
             SiteRadius dataclass
         """
-
         lattice = trajectory.get_lattice()
         site_radius = 2 * vibration_amplitude
 
@@ -620,7 +619,6 @@ class SiteRadius:
 
     def _min_dist(self, sites: Structure):
         """Minimum distance (Angstom) between sites pairs."""
-
         self.min_dist = {}
 
         site_labels = np.array(sites.labels)

--- a/tests/integration/jumps_test.py
+++ b/tests/integration/jumps_test.py
@@ -9,8 +9,8 @@ import pytest
 from gemdat import Jumps, TrajectoryMetrics
 
 
-@pytest.vaspxml_available
-class TestJumps:  # type: ignore
+@pytest.vaspxml_available  # type: ignore
+class TestJumps:
     n_parts = 10
     diffusing_element = 'Li'
 

--- a/tests/integration/transitions_test.py
+++ b/tests/integration/transitions_test.py
@@ -16,8 +16,8 @@ from numpy.testing import assert_allclose
 from gemdat.transitions import SiteRadius
 
 
-@pytest.vaspxml_available
-class TestTransitions:  # type: ignore
+@pytest.vaspxml_available  # type: ignore
+class TestTransitions:
     n_parts = 10
     diffusing_element = 'Li'
 

--- a/tools/flake.lock
+++ b/tools/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1708475490,
-        "narHash": "sha256-g1v0TsWBQPX97ziznfJdWhgMyMGtoBFs102xSYO4syU=",
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0e74ca98a74bc7270d28838369593635a5db3260",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
         "type": "github"
       },
       "original": {

--- a/tools/flake.lock
+++ b/tools/flake.lock
@@ -18,41 +18,7 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
-        "ruff_0_1_5": "ruff_0_1_5",
-        "ruff_287": "ruff_287"
-      }
-    },
-    "ruff_0_1_5": {
-      "locked": {
-        "lastModified": 1699513481,
-        "narHash": "sha256-WeEJXGfXMV4R3O0/zkh2pArElEQjPm6chB1pm0ZD4c0=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "aa1d7f6320c32010a990ba6c78fcb24cf9e99270",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "aa1d7f6320c32010a990ba6c78fcb24cf9e99270",
-        "type": "github"
-      }
-    },
-    "ruff_287": {
-      "locked": {
-        "lastModified": 1693821423,
-        "narHash": "sha256-6Tg5wPUh0HQUJAQ7Yun1X+8K4UY6YV5JTnsEQaROlC4=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "e32a63389adb6ee017f8b344e21c80432bb75c10",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "e32a63389adb6ee017f8b344e21c80432bb75c10",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/tools/flake.nix
+++ b/tools/flake.nix
@@ -4,8 +4,8 @@
   outputs = { self, nixpkgs, ... }:
     let
     pkgs = nixpkgs.legacyPackages.x86_64-linux;
-    mypython = pkgs.python313;
-    pythonpkgs = pkgs.python313Packages;
+    mypython = pkgs.python314;
+    pythonpkgs = pkgs.python314Packages;
     in with pkgs; {
       devShell.x86_64-linux =
         mkShell { buildInputs = [

--- a/tools/flake.nix
+++ b/tools/flake.nix
@@ -1,18 +1,14 @@
 {
   inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-  inputs.ruff_287.url = "github:nixos/nixpkgs/e32a63389adb6ee017f8b344e21c80432bb75c10";
-  inputs.ruff_0_1_5.url = "github:nixos/nixpkgs/aa1d7f6320c32010a990ba6c78fcb24cf9e99270";
 
-  outputs = { self, nixpkgs, ruff_0_1_5, ... }:
+  outputs = { self, nixpkgs, ... }:
     let
     pkgs = nixpkgs.legacyPackages.x86_64-linux;
-    ruffpkg = ruff_0_1_5.legacyPackages.x86_64-linux.ruff;
     mypython = pkgs.python313;
     pythonpkgs = pkgs.python313Packages;
     in with pkgs; {
       devShell.x86_64-linux =
         mkShell { buildInputs = [
-          ruffpkg
           pythonpkgs.numpy
           pythonpkgs.matplotlib
           pythonpkgs.scipy

--- a/tools/flake.nix
+++ b/tools/flake.nix
@@ -14,7 +14,6 @@
           pythonpkgs.scipy
           pythonpkgs.pandas
           pythonpkgs.pyarrow
-          gh
         ];
         pythonWithPkgs = mypython.withPackages (pythonPkgs: with pythonPkgs; [
           # This list contains tools for Python development.

--- a/tools/flake.nix
+++ b/tools/flake.nix
@@ -7,8 +7,8 @@
     let
     pkgs = nixpkgs.legacyPackages.x86_64-linux;
     ruffpkg = ruff_0_1_5.legacyPackages.x86_64-linux.ruff;
-    mypython = pkgs.python311;
-    pythonpkgs = pkgs.python311Packages;
+    mypython = pkgs.python313;
+    pythonpkgs = pkgs.python313Packages;
     in with pkgs; {
       devShell.x86_64-linux =
         mkShell { buildInputs = [
@@ -18,6 +18,7 @@
           pythonpkgs.scipy
           pythonpkgs.pandas
           pythonpkgs.pyarrow
+          gh
         ];
         pythonWithPkgs = mypython.withPackages (pythonPkgs: with pythonPkgs; [
           # This list contains tools for Python development.


### PR DESCRIPTION
## Summary

Make GEMDAT compatible with the latest pymatgen and refresh the dev/CI toolchain.

## Changes

- **Drop the pymatgen upper bound** (`< 2026.3.23`), allowing the newest releases.
- **Fix supercell site labels** (`io.py`): newer pymatgen suffixes duplicate site
  labels with `_1`, `_2`, … when building a supercell. Strip the suffix so
  symmetry-equivalent sites keep a shared label, which the jump/transition analysis
  groups on.
- **Fix typing for ASE trajectories** (`trajectory.py`): use `TrajectoryReader` for
  the read-mode type hint.
- **Allow `np.ndarray` in `ShapeAnalyzer.shift_sites`** (`shape.py`).
- **Resolve mypy errors** arising from ASE/NumPy type changes.
- **CI**: test against Python 3.13 and 3.14; bump GitHub Actions
  (checkout v5, setup-python v6, cache v4) off the deprecated Node 20 runners.
- **pre-commit**: move docformatter to the maintained PyCQA fork (v1.7.8) and bump
  pre-commit-hooks (v6), ruff (v0.15.14), and mypy (v2.1.0); apply the resulting
  docstring/formatting fixes across plots and analysis modules.
- **Update the Nix flake** (`tools/flake.nix` / `flake.lock`).