### PR TITLE
Include constant_lattice in Trajectory cache hashid

### DIFF
--- a/src/gemdat/trajectory.py
+++ b/src/gemdat/trajectory.py
@@ -249,7 +249,8 @@ class Trajectory(PymatgenTrajectory):
         kwargs.setdefault('parse_potcar_file', False)
 
         if not cache:
-            serialized = json.dumps(kwargs, sort_keys=True).encode()
+            hash_kwargs = {**kwargs, 'constant_lattice': constant_lattice}
+            serialized = json.dumps(hash_kwargs, sort_keys=True).encode()
             hashid = hashlib.sha1(serialized).hexdigest()[:8]
             cache = Path(xml_file).with_suffix(f'.xml.{hashid}.cache')
 
@@ -339,6 +340,7 @@ class Trajectory(PymatgenTrajectory):
                 'data_file': data_file,
                 'temperature': temperature,
                 'time_step': time_step,
+                'constant_lattice': constant_lattice,
             }
             serialized = json.dumps(kwargs, sort_keys=True).encode()
             hashid = hashlib.sha1(serialized).hexdigest()[:8]
@@ -439,6 +441,7 @@ class Trajectory(PymatgenTrajectory):
                 'coords_file': coords_file,
                 'edr_file': edr_file,
                 'temperature': temperature,
+                'constant_lattice': constant_lattice,
             }
             serialized = json.dumps(kwargs, sort_keys=True).encode()
             hashid = hashlib.sha1(serialized).hexdigest()[:8]

--- a/tests/integration/cache_test.py
+++ b/tests/integration/cache_test.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import pytest
+
+from gemdat.trajectory import Trajectory
+
+from .conftest import VASP_XML
+
+
+@pytest.vaspxml_available  # type: ignore
+def test_constant_lattice_cache_invalidation(tmp_path):
+    """Changing `constant_lattice` must not reuse a stale cache (issue
+    #393)."""
+    # Symlink avoids copying the large vasprun.xml while keeping the
+    # auto-generated cache files inside tmp_path.
+    xml = tmp_path / 'vasprun.xml'
+    xml.symlink_to(VASP_XML)
+
+    traj_false = Trajectory.from_vasprun(xml, constant_lattice=False)
+    assert traj_false.constant_lattice is False
+
+    traj_true = Trajectory.from_vasprun(xml, constant_lattice=True)
+    assert traj_true.constant_lattice is True
+
+    # Each `constant_lattice` value should produce its own cache file.
+    caches = sorted(tmp_path.glob('vasprun.xml.*.cache'))
+    assert len(caches) == 2


### PR DESCRIPTION
## Summary
- Changing `constant_lattice` (e.g. `False` -> `True`) when reading a `Trajectory` previously reused a stale cache, because the parameter was not part of the cache `hashid`.
- Fold `constant_lattice` into the `hashid` for all readers (`from_vasprun`, `from_lammps`, `from_gromacs`; `from_ase_trajectory` already included it) so a different value produces a distinct cache file.

Fixes #393

## Test plan
- [x] Read a trajectory with `constant_lattice=False`, then again with `constant_lattice=True`, and confirm distinct cache files are produced and the second read does not load the stale cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)