### PR TITLE
Remove polyfill.io CDN dependency from docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,7 +62,6 @@ markdown_extensions:
       generic: true
 
 extra_javascript:
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 
 plugins:


### PR DESCRIPTION
polyfill.io was sold in 2024 and began serving malware, making it a supply-chain risk. MathJax 3 only supports ES6+ browsers, so the polyfill was never used by browsers MathJax actually runs on. Drop it.