### PR TITLE
Fix drift(floating_species=...) for Element species (#406)

### DIFF
--- a/src/gemdat/trajectory.py
+++ b/src/gemdat/trajectory.py
@@ -778,13 +778,15 @@ class Trajectory(PymatgenTrajectory):
         if fixed_species:
             displacements = self.filter(species=fixed_species).displacements
         elif floating_species:
-            species = set()
+            if isinstance(floating_species, str):
+                floating_species = [floating_species]
+            fixed_symbols = set()
             for sp in self.species:
-                assert isinstance(sp, Species), f'got {type(sp)=}'
+                assert isinstance(sp, (Species, Element)), f'got {type(sp)=}'
                 if sp.symbol not in floating_species:
-                    species.add(sp)
+                    fixed_symbols.add(sp.symbol)
 
-            displacements = self.filter(species=species).displacements  # type: ignore
+            displacements = self.filter(species=fixed_symbols).displacements
         else:
             displacements = self.displacements
 

--- a/src/gemdat/trajectory.py
+++ b/src/gemdat/trajectory.py
@@ -757,18 +757,23 @@ class Trajectory(PymatgenTrajectory):
         """Compute drift by averaging the displacement from the base positions
         per frame.
 
-        If no species are specified, use all species to calculate drift.
+        Drift is always computed from the displacement of the *fixed*
+        (framework) species. `fixed_species` names them directly, while
+        `floating_species` names the complement: the fixed species are taken
+        to be every other species in the trajectory. The two arguments are
+        just two ways to select the same fixed set; only one should be given.
 
-        Only one of `fixed_species` and `floating_species` should be specified.
+        If neither is specified, all species are used to calculate drift.
 
         Parameters
         ----------
         fixed_species : None | str | Collection[str]
-            These species are assumed fixed, and are used to calculate drift
-            (e.g. framework species).
+            The fixed (e.g. framework) species. Their displacement is averaged
+            to obtain the drift.
         floating_species : None | str | Collection[str]
-            These species are assumed floating, and is used to determine the
-            fixed species.
+            The floating (diffusing) species. Drift is computed from every
+            species *except* these, i.e. this selects the fixed species by
+            exclusion.
 
         Returns
         -------
@@ -800,20 +805,22 @@ class Trajectory(PymatgenTrajectory):
     ) -> Trajectory:
         """Apply drift correction to trajectory.
 
+        Drift is always computed from the displacement of the *fixed*
+        (framework) species; `floating_species` selects those by exclusion.
         For details see [drift()][gemdat.trajectory.Trajectory.drift].
 
-        If no species are specified, use all species to calculate drift.
-
-        Only one of `fixed_species` and `floating_species` should be specified.
+        If neither is specified, all species are used to calculate drift.
+        Only one of `fixed_species` and `floating_species` should be given.
 
         Parameters
         ----------
         fixed_species : None | str | Collection[str]
-            These species are assumed fixed, and are used to calculate
-            drift (e.g. framework species).
+            The fixed (e.g. framework) species. Their displacement is averaged
+            to obtain the drift.
         floating_species : None | str | Collection[str]
-            These species are assumed floating, and is used to determine
-            the fixed species.
+            The floating (diffusing) species. Drift is computed from every
+            species *except* these, i.e. this selects the fixed species by
+            exclusion.
 
         Returns
         -------

--- a/tests/trajectory_test.py
+++ b/tests/trajectory_test.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import numpy as np
 import scipp as sc
 from numpy.testing import assert_allclose
-from pymatgen.core import Lattice, Species
+from pymatgen.core import Element, Lattice, Species
 
 from gemdat.trajectory import Trajectory
 
@@ -108,6 +108,30 @@ def test_drift_correction(trajectory):
 
     # drift must now be effectively removed
     assert_allclose(global_drift2, [[0.0, 0.0, 0.0]])
+
+
+def test_drift_floating_species(trajectory):
+    # 'C' is the only floating species, so the fixed set is B, Si, S, matching
+    # fixed_species=['B', 'Si', 'S']
+    drift = trajectory.drift(floating_species='C')
+    assert drift.shape == (5, 1, 3)
+    assert not np.isnan(drift).any()
+    assert_allclose(drift, trajectory.drift(fixed_species=['B', 'Si', 'S']))
+
+
+def test_drift_floating_species_element(trajectory):
+    # Trajectories from e.g. from_vasprun carry Element (not Species) sites;
+    # drift(floating_species=...) must accept those too (issue #406).
+    element_traj = Trajectory(
+        species=[Element(sp.symbol) for sp in trajectory.species],
+        coords=trajectory.positions,
+        lattice=trajectory.lattice,
+        metadata=trajectory.metadata,
+        time_step=trajectory.time_step,
+    )
+    drift = element_traj.drift(floating_species='C')
+    assert drift.shape == (5, 1, 3)
+    assert_allclose(drift, trajectory.drift(floating_species='C'))
 
 
 def test_distances_from_base_position(trajectory):


### PR DESCRIPTION
Fixes #406.

`Trajectory.drift(floating_species=...)` (and therefore `apply_drift_correction`) crashed with an `AssertionError` on trajectories whose sites are pymatgen `Element` objects rather than `Species` — e.g. anything loaded via `from_vasprun`.

## What was wrong

The `floating_species` branch was **doubly broken**:

1. **The reported bug:** it asserted every site `isinstance(sp, Species)`, which rejects `Element`. (For the record: `Species` and `Element` are unrelated pymatgen types — neither subclasses the other — but both expose `.symbol`.)
2. **A latent bug the fix surfaced:** it built a `set` of `Species` *objects* and passed it to `filter()`, which compares `sp.symbol` (a `str`) against that set — so the filter matched nothing and `drift` returned all-`NaN` even when the assertion happened to pass.

## The fix

Collect **symbols** (strings) instead of `Species` objects, which is what `filter()` expects and which handles both `Element` and `Species` uniformly (consistent with `filter()` itself). A bare `str` is normalized to a list up front so a symbol like `S` isn't matched as a substring of a floating species like `Si`.

## Tests

- `test_drift_floating_species` — asserts the result is non-`NaN` and equals the equivalent `fixed_species` call.
- `test_drift_floating_species_element` — builds an `Element`-species trajectory and confirms `drift(floating_species='C')` works (the #406 scenario).

All of `tests/trajectory_test.py` passes; mypy is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)