### PR TITLE
Fix mkdocs cross-reference and nav warnings

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,48 @@
+name: Build documentation
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+  workflow_dispatch:
+
+jobs:
+  build-docs:
+    if: github.event.pull_request.draft == false
+    name: Check mkdocs build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Check out docs submodules
+        run: |
+          git submodule update --init docs/notebooks docs/tutorials
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - uses: actions/cache@v5
+        id: cache-virtualenv
+        with:
+          path: ${{ env.pythonLocation }}
+          key: docs-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}
+
+      - name: Install dependencies
+        if: steps.cache-virtualenv.outputs.cache-hit != 'true'
+        run: |
+          python -m pip install -e .[docs]
+
+      - name: Build documentation
+        run: |
+          mkdocs build --strict

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ metrics.vibration_amplitude()
 
 ## Development
 
-Check out our [Contributing Guidelines](CONTRIBUTING.md#Getting-started-with-development) to get started with development.
+Check out our [Contributing Guidelines](CONTRIBUTING.md#getting-started-with-development) to get started with development.
 
 ## How to Cite
 

--- a/docs/api/gemdat_path.md
+++ b/docs/api/gemdat_path.md
@@ -1,0 +1,4 @@
+::: gemdat.path
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false

--- a/docs/plotting.md
+++ b/docs/plotting.md
@@ -14,47 +14,27 @@ plots.radial_distribution(rdfs)
 
 All plotting functions take a [gemdat.Trajectory][], [gemdat.Jumps][], [gemdat.Transitions][], [gemdat.rdf.RDFData][] or a combination as input. In addition, for some plots you have a few parameters to tune the output.
 
+All available plots are documented in the [gemdat.plots API reference](api/gemdat_plots.md). Some highlights are listed below.
 
 ## Trajectory and displacements plots
 
-::: gemdat.plots
-    options:
-      show_root_toc_entry: false
-      heading_level: 3
-      members:
-        - displacement_per_atom
-        - displacement_per_element
-        - displacement_histogram
-
+- [gemdat.plots.displacement_per_atom][]
+- [gemdat.plots.displacement_per_element][]
+- [gemdat.plots.displacement_histogram][]
 
 ## Simulation metrics plots
 
-::: gemdat.plots
-    options:
-      show_root_toc_entry: false
-      heading_level: 3
-      members:
-        - frequency_vs_occurence
-        - vibrational_amplitudes
+- [gemdat.plots.frequency_vs_occurence][]
+- [gemdat.plots.vibrational_amplitudes][]
 
 ## Jumps and transition plots
 
-::: gemdat.plots
-    options:
-      show_root_toc_entry: false
-      heading_level: 3
-      members:
-        - jumps_vs_distance
-        - jumps_vs_time
-        - collective_jumps
-        - jumps_3d
-        - jumps_3d_animation
+- [gemdat.plots.jumps_vs_distance][]
+- [gemdat.plots.jumps_vs_time][]
+- [gemdat.plots.collective_jumps][]
+- [gemdat.plots.jumps_3d][]
+- [gemdat.plots.jumps_3d_animation][]
 
 ## Radial distribution plots
 
-::: gemdat.plots
-    options:
-      show_root_toc_entry: false
-      heading_level: 3
-      members:
-        - radial_distribution
+- [gemdat.plots.radial_distribution][]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,7 +33,7 @@ nav:
     - gemdat.path: api/gemdat_path.md
     - gemdat.plots: api/gemdat_plots.md
     - gemdat.rdf: api/gemdat_rdf.md
-    - gemdat.metrics: api/gemdat_metrics.md
+    - gemdat.metrics: api/gemdat_simulation_metrics.md
     - gemdat.shape: api/gemdat_shape.md
     - gemdat.trajectory: api/gemdat_trajectory.md
     - gemdat.transitions: api/gemdat_transitions.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,7 @@ nav:
     - gemdat: api/gemdat.md
     - gemdat.collective: api/gemdat_collective.md
     - gemdat.io: api/gemdat_io.md
+    - gemdat.path: api/gemdat_path.md
     - gemdat.plots: api/gemdat_plots.md
     - gemdat.rdf: api/gemdat_rdf.md
     - gemdat.metrics: api/gemdat_metrics.md

--- a/src/gemdat/path.py
+++ b/src/gemdat/path.py
@@ -312,7 +312,7 @@ def optimal_n_paths(
         - 'bellman-ford': Bellman-Ford algorithm
         - 'minmax-energy': Minmax energy algorithm
         - 'dijkstra-exp': Dijkstra's algorithm with exponential weights
-    Npaths : int
+    n_paths : int
         Number of paths to be calculated
     min_diff : float
         Minimum difference between the paths

--- a/src/gemdat/path.py
+++ b/src/gemdat/path.py
@@ -149,11 +149,6 @@ class Pathway:
         """See [gemdat.plots.energy_along_path][] for more info."""
         return module.energy_along_path(path=self, **kwargs)
 
-    @plot_backend
-    def plot_path_on_grid(self, module, **kwargs):
-        """See [gemdat.plots.path_on_grid][] for more info."""
-        return module.path_on_grid(path=self, **kwargs)
-
 
 def free_energy_graph(
     F: np.ndarray | FreeEnergyVolume,

--- a/src/gemdat/shape.py
+++ b/src/gemdat/shape.py
@@ -158,7 +158,8 @@ class ShapeAnalyzer:
 
     @classmethod
     def from_structure(cls, structure: Structure):
-        """Construct instance from [Structure][pymatgen.core.Structure].
+        """Construct instance from
+        [Structure][pymatgen.core.structure.Structure].
 
         The input structure will be symmetrized using
         [SpacegroupAnalyzer][pymatgen.symmetry.analyzer.SpacegroupAnalyzer].
@@ -239,7 +240,8 @@ class ShapeAnalyzer:
     ) -> list[ShapeData]:
         """Perform shape analysis on trajectory.
 
-        Similar to [analyze_positions()][ShapeAnalyzer.analyze_positions]. Handles
+        Similar to
+        [analyze_positions()][gemdat.shape.ShapeAnalyzer.analyze_positions]. Handles
         coordinate conversion it trajectory is a supercell of the structure used to
         instantiate this class. The trajectory lattice must be similar or a
         supercell thereof.
@@ -254,7 +256,7 @@ class ShapeAnalyzer:
             lattice.
         radius : float, optional
             Cluster symmetrically equivalent positions
-            within this distance from [unique_sites][ShapeAnalyzer.unique_sites].
+            within this distance from the analyzer's `sites`.
 
         Returns
         -------
@@ -292,7 +294,7 @@ class ShapeAnalyzer:
             lattice.
         radius : float, optional
             Cluster symmetrically equivalent positions
-            within this distance from [unique_sites][ShapeAnalyzer.unique_sites].
+            within this distance from the analyzer's `sites`.
 
         Returns
         -------

--- a/src/gemdat/shape.py
+++ b/src/gemdat/shape.py
@@ -23,8 +23,8 @@ class ShapeData:
 
     Parameters
     ----------
-    name : str
-        Name or label for associated with this shape
+    site : PeriodicSite
+        Site associated with this shape
     coords : np.ndarray
         (n, 3) coordinate array in cartesian system (Å)
     radius : float
@@ -288,10 +288,6 @@ class ShapeAnalyzer:
         positions : np.ndarray
             (n, 3) input array fractional coordinates. These must correspond to
             the same lattice as the structure used to instantiate this class.
-        supercell : None | tuple[float, float, float], optional
-            If the trajectory is in a supercell of the input structure,
-            the given supercell used to fold trajectory positions into same
-            lattice.
         radius : float, optional
             Cluster symmetrically equivalent positions
             within this distance from the analyzer's `sites`.

--- a/src/gemdat/volume.py
+++ b/src/gemdat/volume.py
@@ -323,7 +323,7 @@ class Volume:
         peaks : Optional[np.ndarray]
             Voxel coordinates to use as starting points for watershed algorithm.
         **kwargs : dict
-            These keywords parameters are passed to [gemdat.Volume.find_peaks][].
+            These keywords parameters are passed to [gemdat.volume.Volume.find_peaks][].
             Only applies if `peaks == None`.
 
         Returns


### PR DESCRIPTION
Fixes #410.

Running `mkdocs build` produced a batch of warnings about unresolved internal links, nav entries, and duplicate anchors. This PR resolves all of them:

## Unresolved cross-references
- **`shape.py`**: fully qualify autoref targets (`pymatgen.core.structure.Structure`, `gemdat.shape.ShapeAnalyzer.analyze_positions`) and drop references to the nonexistent `ShapeAnalyzer.unique_sites` attribute (the actual attribute is `sites`)
- **`volume.py`**: fix `gemdat.Volume.find_peaks` → `gemdat.volume.Volume.find_peaks`
- Add the missing API docs page for `gemdat.path` (and add it to the nav), so the `gemdat.path.*` references from `volume.py` resolve

## Nav and duplicate-anchor warnings
- **`mkdocs.yml`**: nav pointed at `api/gemdat_metrics.md`, but the file is `api/gemdat_simulation_metrics.md` (kept the existing filename since tutorials link to its published URL). Fixes both the "not found" and "not in nav" warnings.
- **`docs/plotting.md`**: replace the `::: gemdat.plots` mkdocstrings blocks with cross-reference links to the `gemdat.plots` API page, so each plot function is documented in one place. Fixes all "Multiple primary URLs" autorefs warnings.

## Dead code removed
- **`path.py`**: remove `Pathway.plot_path_on_grid` — it referenced and called `gemdat.plots.path_on_grid`, which was removed in ab88cee (#313), so the method could only raise `AttributeError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)