### PR TITLE
Drop README.md from bump-my-version config to unblock releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,8 +143,3 @@ replace = "version = \"{new_version}\""
 filename = "CITATION.cff"
 search = "version: {current_version}"
 replace = "version: {new_version}"
-
-[[tool.bumpversion.files]]
-filename = "README.md"
-search = "(Version {current_version})"
-replace = "(Version {new_version})"


### PR DESCRIPTION
The 1.7.3 release workflow failed in the "Bump version to new tag" step:

```
Error: Did not find '(Version 1.7.2)' in file: 'README.md'
```

Commit 414ef43 replaced the Zenodo software citation in the README's *How to Cite* section (which contained `GEMDAT (Version 1.7.2)`) with the published npj Comput Mater paper citation, which has no version string. The `[tool.bumpversion]` config still tried to rewrite it, and bump-my-version treats a missing search string as a hard error.

Since the version no longer appears anywhere in the README, this removes the README block from the bumpversion file list. Verified with `bump-my-version bump --dry-run`: `__init__.py`, `pyproject.toml`, and `CITATION.cff` are still bumped, no README error.

After merging, the 1.7.3 release can be re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)