### PR TITLE
Fix publish workflow crash on Python 3.10 (no tomllib)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -21,7 +21,8 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip pip-tools setuptools
+        # tomli backports tomllib, which tools/generate_requirements_txt.py needs on 3.10.
+        python -m pip install --upgrade pip pip-tools setuptools tomli
 
     - name: Set configuration
       run: |

--- a/tools/generate_requirements_txt.py
+++ b/tools/generate_requirements_txt.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
-import tomllib
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    # tomllib is stdlib from Python 3.11; 3.10 needs the backport it was based on.
+    import tomli as tomllib
 
 this_script = Path(__file__)
 root = this_script.parents[1]


### PR DESCRIPTION
## Problem

The 1.7.4 release failed: [run 31113795984](https://github.com/GEMDAT-repos/GEMDAT/actions/runs/31113795984).

```
File "tools/generate_requirements_txt.py", line 5, in <module>
    import tomllib
ModuleNotFoundError: No module named 'tomllib'
```

#423 replaced `publish.yaml`'s hardcoded `python-version: '3.11'` with the new
`supported-python` action's `oldest` output, which is `3.10`. `tomllib` is stdlib only from
Python 3.11 (PEP 680), so `tools/generate_requirements_txt.py` no longer imports.

The `supported-python` composite action itself is fine — it deliberately runs `tomllib` on the
runner's preinstalled `python3` before any `setup-python` step. Only the downstream job step
got downgraded.

Since `deploy` has `needs: fix_release_deps`, it was skipped and **1.7.4 never reached PyPI**.

## Fix

Keep `fix_release_deps` on the oldest supported Python — that looks deliberate, so `pip-compile`
resolves `requirements_full.txt` against the version floor — and fall back to the `tomli`
backport there instead.

A `sys.version_info` guard is used rather than `try` / `except ImportError`, because mypy
rejects the latter:

```
tools/generate_requirements_txt.py:9: error: Name "tomllib" already defined (by an import)  [no-redef]
```

and it narrows the version check natively, so no `# type: ignore` is needed.

## Verification

- Script runs clean on Python 3.14 (`tomllib` branch); output byte-identical to the committed `requirements.txt`.
- Forced the `else` branch with `tomli` on the path — also byte-identical, so the backport parses `pyproject.toml` the same way.
- `pre-commit run --files ...` passes all hooks, including mypy.

## Note for whoever cuts the release

Re-running the failed run will **not** pick this up. For `release: published` events the workflow
file comes from the commit the tag points at (`ce130c7`), which still has the broken version.
`workflow_dispatch` isn't a substitute either — it runs with `GITHUB_REF_NAME=main`, so
`bump-my-version bump --new-version $GITHUB_REF_NAME` would try to bump to version "main".

After this lands, the `1.7.4` tag and release need to be deleted and recreated against a commit
that contains this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)