### PR TITLE
Crystallizer: symmetry ranking + settable / Top-X space group (#421 pts 1, 5)

### DIFF
--- a/docs/api/gemdat_symmetry.md
+++ b/docs/api/gemdat_symmetry.md
@@ -1,0 +1,4 @@
+::: gemdat.symmetry
+    options:
+      show_root_heading: false
+      show_root_toc_entry: false

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,7 @@ nav:
     - gemdat.rdf: api/gemdat_rdf.md
     - gemdat.metrics: api/gemdat_simulation_metrics.md
     - gemdat.shape: api/gemdat_shape.md
+    - gemdat.symmetry: api/gemdat_symmetry.md
     - gemdat.trajectory: api/gemdat_trajectory.md
     - gemdat.transitions: api/gemdat_transitions.md
     - gemdat.jumps: api/gemdat_jumps.md

--- a/src/gemdat/__init__.py
+++ b/src/gemdat/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from .crystallizer import Crystallizer, CrystallizerResult
+from .crystallizer import Crystallizer, CrystallizerResult, CrystallizerScan
 from .io import load_known_material, read_cif, write_cif
 from .jumps import Jumps
 from .metrics import TrajectoryMetrics
@@ -16,6 +16,7 @@ __version__ = '1.8.0'
 __all__ = [
     'Crystallizer',
     'CrystallizerResult',
+    'CrystallizerScan',
     'Jumps',
     'load_known_material',
     'Orientations',

--- a/src/gemdat/__init__.py
+++ b/src/gemdat/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from .crystallizer import Crystallizer, CrystallizerResult
+from .crystallizer import Crystallizer, CrystallizerResult, SymmetryLevel
 from .io import load_known_material, read_cif, write_cif
 from .jumps import Jumps
 from .metrics import TrajectoryMetrics
@@ -21,6 +21,7 @@ __all__ = [
     'radial_distribution',
     'read_cif',
     'ShapeAnalyzer',
+    'SymmetryLevel',
     'TrajectoryMetrics',
     'Trajectory',
     'trajectory_to_volume',

--- a/src/gemdat/__init__.py
+++ b/src/gemdat/__init__.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from .crystallizer import Crystallizer, CrystallizerResult, SymmetryLevel
+from .crystallizer import Crystallizer, CrystallizerResult
 from .io import load_known_material, read_cif, write_cif
 from .jumps import Jumps
 from .metrics import TrajectoryMetrics
 from .orientations import Orientations
 from .rdf import radial_distribution
 from .shape import ShapeAnalyzer
+from .symmetry import SymmetryAnalyzer, SymmetryLevel, SymmetryRanking
 from .trajectory import Trajectory
 from .transitions import Transitions
 from .volume import Volume, trajectory_to_volume
@@ -21,7 +22,9 @@ __all__ = [
     'radial_distribution',
     'read_cif',
     'ShapeAnalyzer',
+    'SymmetryAnalyzer',
     'SymmetryLevel',
+    'SymmetryRanking',
     'TrajectoryMetrics',
     'Trajectory',
     'trajectory_to_volume',

--- a/src/gemdat/crystallizer.py
+++ b/src/gemdat/crystallizer.py
@@ -12,135 +12,13 @@ from pymatgen.core import Structure
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 
 from .io import write_cif
+from .symmetry import SymmetryAnalyzer, SymmetryLevel, SymmetryRanking
 from .utils import require_constant_lattice
 
 if TYPE_CHECKING:
     from pathlib import Path
 
     from .trajectory import Trajectory
-
-
-@dataclass
-class SymmetryLevel:
-    """One rung of the symmetry ladder: the space group found at a single
-    symmetry tolerance.
-
-    Parameters
-    ----------
-    symprec : float
-        Symmetry tolerance (in Ångstrom) at which this level was evaluated.
-    spacegroup_number : int | None
-        International number of the space group, or `None` if the symmetry
-        search failed at this tolerance.
-    spacegroup_symbol : str | None
-        International (Hermann-Mauguin) symbol, or `None` on failure.
-    crystal_system : str | None
-        Crystal system (e.g. `'cubic'`), or `None` on failure.
-    n_symmetry_ops : int | None
-        Number of symmetry operations in the space group, or `None` on failure.
-    n_site_orbits : int | None
-        Number of symmetry-distinct site groups (orbits), or `None` on failure.
-    error : str | None
-        The exception message if the symmetry search raised, else `None`.
-    """
-
-    symprec: float
-    spacegroup_number: int | None = None
-    spacegroup_symbol: str | None = None
-    crystal_system: str | None = None
-    n_symmetry_ops: int | None = None
-    n_site_orbits: int | None = None
-    error: str | None = None
-
-
-def _build_symmetry_level(
-    geometry: Structure,
-    symprec: float,
-    angle_tolerance: float,
-) -> SymmetryLevel:
-    """Evaluate the space group of `geometry` at a single `symprec`.
-
-    Any exception raised by
-    [pymatgen.symmetry.analyzer.SpacegroupAnalyzer][] is caught and
-    stored on the returned level rather than propagated, so a sweep can
-    continue past a tolerance that fails.
-    """
-    try:
-        sga = SpacegroupAnalyzer(geometry, symprec=symprec, angle_tolerance=angle_tolerance)
-        symmetrized = sga.get_symmetrized_structure()
-        return SymmetryLevel(
-            symprec=symprec,
-            spacegroup_number=sga.get_space_group_number(),
-            spacegroup_symbol=sga.get_space_group_symbol(),
-            crystal_system=sga.get_crystal_system(),
-            n_symmetry_ops=len(sga.get_symmetry_operations()),
-            n_site_orbits=len(symmetrized.equivalent_indices),
-        )
-    except Exception as exc:  # noqa: BLE001 - record, don't drop, the failure
-        return SymmetryLevel(symprec=symprec, error=str(exc))
-
-
-def _normalize_spacegroup_symbol(symbol: str) -> str:
-    """Strip all whitespace and lower-case a Hermann-Mauguin symbol for
-    tolerant matching."""
-    return ''.join(symbol.split()).lower()
-
-
-def _match_target_spacegroup(
-    levels: list[SymmetryLevel],
-    target: int | str,
-) -> SymmetryLevel | None:
-    """Return the first level in `levels` matching `target` (an international
-    number or a Hermann-Mauguin symbol), or `None` if nothing matches.
-
-    `levels` is expected in ascending-symprec order, so the first match
-    is the tightest tolerance that yields the target.
-    """
-    if isinstance(target, str):
-        wanted = _normalize_spacegroup_symbol(target)
-        for level in levels:
-            if level.spacegroup_symbol is not None and (
-                _normalize_spacegroup_symbol(level.spacegroup_symbol) == wanted
-            ):
-                return level
-        return None
-
-    for level in levels:
-        if level.spacegroup_number == target:
-            return level
-    return None
-
-
-def _format_ladder(levels: list[SymmetryLevel]) -> str:
-    """Render a list of [SymmetryLevel][gemdat.crystallizer.SymmetryLevel] as a
-    fixed-width text table."""
-    headers = ('symprec (Å)', 'space group', '#', 'crystal system', '# orbits')
-    rows: list[tuple[str, str, str, str, str]] = []
-    for level in levels:
-        if level.spacegroup_number is None:
-            rows.append((f'{level.symprec:g}', 'failed', '-', '-', '-'))
-        else:
-            orbits = str(level.n_site_orbits) if level.n_site_orbits is not None else '-'
-            rows.append(
-                (
-                    f'{level.symprec:g}',
-                    level.spacegroup_symbol or '-',
-                    str(level.spacegroup_number),
-                    level.crystal_system or '-',
-                    orbits,
-                )
-            )
-
-    widths = [
-        max([len(headers[i])] + [len(row[i]) for row in rows]) for i in range(len(headers))
-    ]
-
-    def _fmt(cells: tuple[str, ...]) -> str:
-        return '  '.join(cell.ljust(width) for cell, width in zip(cells, widths))
-
-    lines = [_fmt(headers), _fmt(tuple('-' * width for width in widths))]
-    lines += [_fmt(row) for row in rows]
-    return '\n'.join(lines)
 
 
 @dataclass
@@ -159,45 +37,57 @@ class CrystallizerResult:
         International number of the fitted space group.
     symprec : float
         Symmetry tolerance (in Ångstrom) that produced the fit.
-    ladder : list[SymmetryLevel] | None
-        The full symmetry ladder (one [SymmetryLevel][gemdat.crystallizer.Symmet
-        ryLevel] per swept symprec), or `None` when `symprec` was set explicitly
-        and no sweep was run.
-    candidates : list[SymmetryLevel] | None
-        The distinct space groups found across the sweep ("Top-X"), ranked by
-        space-group number descending, each represented by the tightest symprec
-        that produced it. `None` when no sweep was run.
+    ranking : SymmetryRanking | None
+        The full symmetry ranking: one
+        [SymmetryLevel][gemdat.symmetry.SymmetryLevel] per distinct space
+        group found by the automatic scan, ordered by required `deviation`
+        ascending, or one per tolerance (symprec ascending) when
+        `symprec_range` was given explicitly. `None` when `symprec` was set
+        explicitly and no sweep was run.
     """
 
     structure: Structure
     spacegroup_symbol: str
     spacegroup_number: int
     symprec: float
-    ladder: list[SymmetryLevel] | None = None
-    candidates: list[SymmetryLevel] | None = None
+    ranking: SymmetryRanking | None = None
 
-    def format_ladder(self) -> str:
-        """Return the symmetry ladder as a readable fixed-width table.
+    @property
+    def candidates(self) -> list[SymmetryLevel] | None:
+        """The distinct space groups found across the sweep ("Top-X").
+
+        Returns
+        -------
+        list[SymmetryLevel] | None
+            One level per space group, ranked by space-group number
+            descending, each represented by the tightest symprec that produced
+            it. `None` when no sweep was run.
+        """
+        if self.ranking is None:
+            return None
+        return self.ranking.candidates
+
+    def format_ranking(self) -> str:
+        """Return the symmetry ranking as a readable fixed-width table.
+
+        See [SymmetryRanking.format][gemdat.symmetry.SymmetryRanking.format].
 
         Returns
         -------
         str
-            One row per swept symprec, with columns `symprec (Å)`,
-            `space group`, `#`, `crystal system` and `# orbits`. A tolerance at
-            which the symmetry search failed shows `failed`/`-`.
 
         Raises
         ------
         ValueError
-            If this result carries no ladder (i.e. `symprec` was set
+            If this result carries no ranking (i.e. `symprec` was set
             explicitly, so no sweep was performed).
         """
-        if self.ladder is None:
+        if self.ranking is None:
             raise ValueError(
-                'This result has no symmetry ladder because `symprec` was set '
-                'explicitly. Call `Crystallizer.symmetry_ladder()` instead.'
+                'This result has no symmetry ranking because `symprec` was set '
+                'explicitly. Call `Crystallizer.symmetry_ranking()` instead.'
             )
-        return _format_ladder(self.ladder)
+        return self.ranking.format()
 
 
 class Crystallizer:
@@ -368,26 +258,48 @@ class Crystallizer:
         )
         return geometry, np.array(occupancies)
 
-    def symmetry_ladder(
+    def symmetry_ranking(
         self,
         *,
-        symprec_range: tuple[float, ...] = (0.01, 0.05, 0.1, 0.2, 0.3, 0.5),
+        symprec_range: tuple[float, ...] | None = None,
+        symprec_min: float = 0.01,
+        symprec_max: float = 0.5,
+        n_samples: int = 40,
         angle_tolerance: float = 5.0,
         background_level: float = 0.1,
         **find_peaks_kwargs,
-    ) -> list[SymmetryLevel]:
-        """Fit the space group of the reconstructed geometry at a range of
-        symmetry tolerances.
+    ) -> SymmetryRanking:
+        """Rank the space groups the reconstructed geometry can adopt by the
+        symmetry tolerance each one requires.
 
         This shows which sub-symmetries appear and at what precision (in
         Ångstrom): loosening `symprec` typically climbs from P1 towards the
         parent space group, and the number of symmetry-distinct site orbits
         drops accordingly.
 
+        By default the tolerances are found automatically: the range is
+        scanned for the space groups the geometry can adopt, and for each one
+        the tolerance it actually requires is measured (`deviation`, in
+        Ångstrom, and `angle_deviation`, in degrees) rather than read off the
+        sampling grid. The result is one row per space group instead of one
+        row per hand-picked tolerance. Pass `symprec_range` to evaluate a
+        fixed list of tolerances instead.
+
         Parameters
         ----------
-        symprec_range : tuple[float, ...]
-            Symmetry tolerances (Ångstrom) to evaluate.
+        symprec_range : tuple[float, ...] | None
+            If given, evaluate exactly these tolerances (Ångstrom) and skip
+            the automatic scan; the result then has one level per tolerance,
+            including duplicated space groups.
+        symprec_min : float
+            Tightest tolerance (Ångstrom) of the automatic scan.
+        symprec_max : float
+            Loosest tolerance (Ångstrom) of the automatic scan. Beyond ~0.5 Å
+            the fit says more about the tolerance than about the structure.
+        n_samples : int
+            Number of log-spaced tolerances in the scan. A space group holding
+            over a window narrower than the grid spacing can be missed; raise
+            this to scan more finely.
         angle_tolerance : float
             Angle tolerance (degrees) passed to
             [pymatgen.symmetry.analyzer.SpacegroupAnalyzer][].
@@ -398,39 +310,55 @@ class Crystallizer:
 
         Returns
         -------
-        list[SymmetryLevel]
-            One [SymmetryLevel][gemdat.crystallizer.SymmetryLevel] per symprec,
-            ordered by symprec ascending. A tolerance at which the symmetry
-            search raised is kept with `None` fields and its `error` set.
+        SymmetryRanking
+            From the automatic scan: one
+            [SymmetryLevel][gemdat.symmetry.SymmetryLevel] per distinct space
+            group, ordered by `deviation` ascending, with `deviation`,
+            `angle_deviation` and `n_observed` set. From an explicit
+            `symprec_range`: one per tolerance, ordered by symprec ascending,
+            where a tolerance at which the symmetry search raised is kept with
+            `None` fields and its `error` set.
         """
         geometry, _ = self._geometry_and_occupancies(
             background_level=background_level, **find_peaks_kwargs
         )
-        return [
-            _build_symmetry_level(geometry, symprec, angle_tolerance)
-            for symprec in sorted(symprec_range)
-        ]
+        analyzer = SymmetryAnalyzer(geometry, angle_tolerance=angle_tolerance)
+        if symprec_range is not None:
+            return analyzer.levels(symprec_range)
+        return analyzer.scan(
+            symprec_min=symprec_min,
+            symprec_max=symprec_max,
+            n_samples=n_samples,
+        )
 
     def crystallize(
         self,
         *,
         symprec: float | None = None,
         target_spacegroup: int | str | None = None,
-        symprec_range: tuple[float, ...] = (0.01, 0.05, 0.1, 0.2, 0.3, 0.5),
+        symprec_range: tuple[float, ...] | None = None,
+        symprec_min: float = 0.01,
+        symprec_max: float = 0.5,
+        n_samples: int = 40,
         angle_tolerance: float = 5.0,
         background_level: float = 0.1,
         **find_peaks_kwargs,
     ) -> CrystallizerResult:
         """Build the full structure and fit a space group.
 
-        By default the symmetry tolerance is swept over `symprec_range` and the
-        tolerance giving the highest space group number wins (ties broken
-        towards the tightest tolerance). This can be overridden:
+        By default the symmetry tolerance is swept automatically (see
+        [symmetry_ranking][gemdat.crystallizer.Crystallizer.symmetry_ranking]):
+        every space group the geometry adopts between `symprec_min` and
+        `symprec_max` is found, together with the deviation it requires, and
+        the highest space group number wins (ties broken towards the tightest
+        tolerance). This can be overridden:
 
         - pass `symprec` to skip the sweep and fit at exactly that tolerance
           ("set it if you are sure what it should be");
         - pass `target_spacegroup` to pick the tightest tolerance in the sweep
-          that yields that space group.
+          that yields that space group;
+        - pass `symprec_range` to sweep a fixed list of tolerances instead of
+          scanning automatically.
 
         Parameters
         ----------
@@ -440,16 +368,23 @@ class Crystallizer:
             the symmetry search fails at this tolerance (no silent fallback).
             Mutually exclusive with `target_spacegroup`.
         target_spacegroup : int | str | None
-            If given, select the tightest (smallest) symprec in `symprec_range`
-            whose fit matches this space group. An `int` is matched against the
+            If given, select the tightest (smallest) symprec in the sweep whose
+            fit matches this space group. An `int` is matched against the
             international number, a `str` against the Hermann-Mauguin symbol
             (case-insensitive, whitespace-insensitive). Raises `ValueError`
             listing what was found at each symprec if nothing matches. Mutually
             exclusive with `symprec`.
-        symprec_range : tuple[float, ...]
-            Symmetry tolerances (Ångstrom) to try when sweeping. The tolerance
-            giving the highest space group number wins; ties are broken towards
-            the tightest (smallest) tolerance.
+        symprec_range : tuple[float, ...] | None
+            If given, sweep exactly these tolerances (Ångstrom) instead of
+            scanning `symprec_min`..`symprec_max` automatically. The tolerance
+            giving the highest space group number wins either way; ties are
+            broken towards the tightest (smallest) tolerance.
+        symprec_min : float
+            Tightest tolerance (Ångstrom) of the automatic scan.
+        symprec_max : float
+            Loosest tolerance (Ångstrom) of the automatic scan.
+        n_samples : int
+            Number of log-spaced tolerances in the automatic scan.
         angle_tolerance : float
             Angle tolerance (degrees) passed to
             [pymatgen.symmetry.analyzer.SpacegroupAnalyzer][].
@@ -462,9 +397,9 @@ class Crystallizer:
         -------
         result : CrystallizerResult
             The symmetrized structure and the fitted space group. When a sweep
-            was run, `result.ladder` holds the full symmetry ladder and
-            `result.candidates` the distinct space groups found, ranked by
-            number descending.
+            was run, `result.ranking` holds the full symmetry ranking (ordered
+            by required deviation ascending) and `result.candidates` the
+            distinct space groups found, ranked by number descending.
 
         Raises
         ------
@@ -483,53 +418,37 @@ class Crystallizer:
             background_level=background_level, **find_peaks_kwargs
         )
 
-        ladder: list[SymmetryLevel] | None = None
-        candidates: list[SymmetryLevel] | None = None
+        analyzer = SymmetryAnalyzer(geometry, angle_tolerance=angle_tolerance)
+        ranking: SymmetryRanking | None = None
 
         if symprec is not None:
-            level = _build_symmetry_level(geometry, symprec, angle_tolerance)
+            level = analyzer.level(symprec)
             if level.spacegroup_number is None:
                 raise ValueError(
                     f'Could not determine symmetry at symprec={symprec}: {level.error}'
                 )
             best_symprec = symprec
         else:
-            ladder = [
-                _build_symmetry_level(geometry, sp, angle_tolerance)
-                for sp in sorted(symprec_range)
-            ]
-            found = [lvl for lvl in ladder if lvl.spacegroup_number is not None]
-            if not found:
-                raise ValueError(
-                    'Could not determine symmetry for any of the given symprec values.'
+            if symprec_range is not None:
+                ranking = analyzer.levels(symprec_range)
+            else:
+                ranking = analyzer.scan(
+                    symprec_min=symprec_min,
+                    symprec_max=symprec_max,
+                    n_samples=n_samples,
                 )
 
-            # Distinct space groups, tightest symprec each (ladder is
-            # symprec-ascending), ranked by number descending -> "Top-X".
-            seen: dict[int, SymmetryLevel] = {}
-            for lvl in found:
-                assert lvl.spacegroup_number is not None
-                seen.setdefault(lvl.spacegroup_number, lvl)
-            candidates = sorted(
-                seen.values(),
-                key=lambda lvl: lvl.spacegroup_number or 0,
-                reverse=True,
-            )
-
             if target_spacegroup is not None:
-                match = _match_target_spacegroup(found, target_spacegroup)
+                match = ranking.match(target_spacegroup)
                 if match is None:
                     raise ValueError(
                         f'No symprec in the sweep produced space group '
-                        f'{target_spacegroup!r}. Found:\n' + _format_ladder(ladder)
+                        f'{target_spacegroup!r}. Found:\n' + ranking.format()
                     )
                 best_symprec = match.symprec
             else:
-                best = max(
-                    found,
-                    key=lambda lvl: (lvl.spacegroup_number or 0, -lvl.symprec),
-                )
-                best_symprec = best.symprec
+                # Raises if no tolerance in the sweep yielded a symmetry.
+                best_symprec = ranking.best().symprec
 
         sga = SpacegroupAnalyzer(
             geometry, symprec=best_symprec, angle_tolerance=angle_tolerance
@@ -558,8 +477,7 @@ class Crystallizer:
             spacegroup_symbol=sga.get_space_group_symbol(),
             spacegroup_number=sga.get_space_group_number(),
             symprec=best_symprec,
-            ladder=ladder,
-            candidates=candidates,
+            ranking=ranking,
         )
 
     def to_cif(self, filename: Path | str, **kwargs) -> CrystallizerResult:

--- a/src/gemdat/crystallizer.py
+++ b/src/gemdat/crystallizer.py
@@ -399,7 +399,7 @@ class Crystallizer:
 
         By default the symmetry tolerance is swept automatically (see
         [symmetry_ranking][gemdat.crystallizer.Crystallizer.symmetry_ranking]):
-        every space group the geometry adopts between `symprec_min` and
+        every space group the geometry recovered between `symprec_min` and
         `symprec_max` is found, together with the deviation it requires, and
         the highest space group number wins (ties broken towards the tightest
         tolerance). This can be overridden:
@@ -416,7 +416,7 @@ class Crystallizer:
         symprec : float | None
             If given, fit at exactly this tolerance (Ångstrom) and skip the
             sweep. `result.symprec` equals this value. Raises `ValueError` if
-            the symmetry search fails at this tolerance (no silent fallback).
+            the symmetry search fails at this tolerance.
             Mutually exclusive with `target_spacegroup` and with every setting
             that configures the sweep.
         target_spacegroup : int | str | None

--- a/src/gemdat/crystallizer.py
+++ b/src/gemdat/crystallizer.py
@@ -21,6 +21,129 @@ if TYPE_CHECKING:
 
 
 @dataclass
+class SymmetryLevel:
+    """One rung of the symmetry ladder: the space group found at a single
+    symmetry tolerance.
+
+    Parameters
+    ----------
+    symprec : float
+        Symmetry tolerance (in Ångstrom) at which this level was evaluated.
+    spacegroup_number : int | None
+        International number of the space group, or `None` if the symmetry
+        search failed at this tolerance.
+    spacegroup_symbol : str | None
+        International (Hermann-Mauguin) symbol, or `None` on failure.
+    crystal_system : str | None
+        Crystal system (e.g. `'cubic'`), or `None` on failure.
+    n_symmetry_ops : int | None
+        Number of symmetry operations in the space group, or `None` on failure.
+    n_site_orbits : int | None
+        Number of symmetry-distinct site groups (orbits), or `None` on failure.
+    error : str | None
+        The exception message if the symmetry search raised, else `None`.
+    """
+
+    symprec: float
+    spacegroup_number: int | None = None
+    spacegroup_symbol: str | None = None
+    crystal_system: str | None = None
+    n_symmetry_ops: int | None = None
+    n_site_orbits: int | None = None
+    error: str | None = None
+
+
+def _build_symmetry_level(
+    geometry: Structure,
+    symprec: float,
+    angle_tolerance: float,
+) -> SymmetryLevel:
+    """Evaluate the space group of `geometry` at a single `symprec`.
+
+    Any exception raised by
+    [pymatgen.symmetry.analyzer.SpacegroupAnalyzer][] is caught and
+    stored on the returned level rather than propagated, so a sweep can
+    continue past a tolerance that fails.
+    """
+    try:
+        sga = SpacegroupAnalyzer(geometry, symprec=symprec, angle_tolerance=angle_tolerance)
+        symmetrized = sga.get_symmetrized_structure()
+        return SymmetryLevel(
+            symprec=symprec,
+            spacegroup_number=sga.get_space_group_number(),
+            spacegroup_symbol=sga.get_space_group_symbol(),
+            crystal_system=sga.get_crystal_system(),
+            n_symmetry_ops=len(sga.get_symmetry_operations()),
+            n_site_orbits=len(symmetrized.equivalent_indices),
+        )
+    except Exception as exc:  # noqa: BLE001 - record, don't drop, the failure
+        return SymmetryLevel(symprec=symprec, error=str(exc))
+
+
+def _normalize_spacegroup_symbol(symbol: str) -> str:
+    """Strip all whitespace and lower-case a Hermann-Mauguin symbol for
+    tolerant matching."""
+    return ''.join(symbol.split()).lower()
+
+
+def _match_target_spacegroup(
+    levels: list[SymmetryLevel],
+    target: int | str,
+) -> SymmetryLevel | None:
+    """Return the first level in `levels` matching `target` (an international
+    number or a Hermann-Mauguin symbol), or `None` if nothing matches.
+
+    `levels` is expected in ascending-symprec order, so the first match
+    is the tightest tolerance that yields the target.
+    """
+    if isinstance(target, str):
+        wanted = _normalize_spacegroup_symbol(target)
+        for level in levels:
+            if level.spacegroup_symbol is not None and (
+                _normalize_spacegroup_symbol(level.spacegroup_symbol) == wanted
+            ):
+                return level
+        return None
+
+    for level in levels:
+        if level.spacegroup_number == target:
+            return level
+    return None
+
+
+def _format_ladder(levels: list[SymmetryLevel]) -> str:
+    """Render a list of [SymmetryLevel][gemdat.crystallizer.SymmetryLevel] as a
+    fixed-width text table."""
+    headers = ('symprec (Å)', 'space group', '#', 'crystal system', '# orbits')
+    rows: list[tuple[str, str, str, str, str]] = []
+    for level in levels:
+        if level.spacegroup_number is None:
+            rows.append((f'{level.symprec:g}', 'failed', '-', '-', '-'))
+        else:
+            orbits = str(level.n_site_orbits) if level.n_site_orbits is not None else '-'
+            rows.append(
+                (
+                    f'{level.symprec:g}',
+                    level.spacegroup_symbol or '-',
+                    str(level.spacegroup_number),
+                    level.crystal_system or '-',
+                    orbits,
+                )
+            )
+
+    widths = [
+        max([len(headers[i])] + [len(row[i]) for row in rows]) for i in range(len(headers))
+    ]
+
+    def _fmt(cells: tuple[str, ...]) -> str:
+        return '  '.join(cell.ljust(width) for cell, width in zip(cells, widths))
+
+    lines = [_fmt(headers), _fmt(tuple('-' * width for width in widths))]
+    lines += [_fmt(row) for row in rows]
+    return '\n'.join(lines)
+
+
+@dataclass
 class CrystallizerResult:
     """Result of [crystallize][gemdat.crystallizer.Crystallizer.crystallize].
 
@@ -35,13 +158,46 @@ class CrystallizerResult:
     spacegroup_number : int
         International number of the fitted space group.
     symprec : float
-        Symmetry tolerance (in Ångstrom) that produced the highest-symmetry fit.
+        Symmetry tolerance (in Ångstrom) that produced the fit.
+    ladder : list[SymmetryLevel] | None
+        The full symmetry ladder (one [SymmetryLevel][gemdat.crystallizer.Symmet
+        ryLevel] per swept symprec), or `None` when `symprec` was set explicitly
+        and no sweep was run.
+    candidates : list[SymmetryLevel] | None
+        The distinct space groups found across the sweep ("Top-X"), ranked by
+        space-group number descending, each represented by the tightest symprec
+        that produced it. `None` when no sweep was run.
     """
 
     structure: Structure
     spacegroup_symbol: str
     spacegroup_number: int
     symprec: float
+    ladder: list[SymmetryLevel] | None = None
+    candidates: list[SymmetryLevel] | None = None
+
+    def format_ladder(self) -> str:
+        """Return the symmetry ladder as a readable fixed-width table.
+
+        Returns
+        -------
+        str
+            One row per swept symprec, with columns `symprec (Å)`,
+            `space group`, `#`, `crystal system` and `# orbits`. A tolerance at
+            which the symmetry search failed shows `failed`/`-`.
+
+        Raises
+        ------
+        ValueError
+            If this result carries no ladder (i.e. `symprec` was set
+            explicitly, so no sweep was performed).
+        """
+        if self.ladder is None:
+            raise ValueError(
+                'This result has no symmetry ladder because `symprec` was set '
+                'explicitly. Call `Crystallizer.symmetry_ladder()` instead.'
+            )
+        return _format_ladder(self.ladder)
 
 
 class Crystallizer:
@@ -212,22 +368,88 @@ class Crystallizer:
         )
         return geometry, np.array(occupancies)
 
-    def crystallize(
+    def symmetry_ladder(
         self,
         *,
         symprec_range: tuple[float, ...] = (0.01, 0.05, 0.1, 0.2, 0.3, 0.5),
         angle_tolerance: float = 5.0,
         background_level: float = 0.1,
         **find_peaks_kwargs,
-    ) -> CrystallizerResult:
-        """Build the full structure and fit the highest possible space group.
+    ) -> list[SymmetryLevel]:
+        """Fit the space group of the reconstructed geometry at a range of
+        symmetry tolerances.
+
+        This shows which sub-symmetries appear and at what precision (in
+        Ångstrom): loosening `symprec` typically climbs from P1 towards the
+        parent space group, and the number of symmetry-distinct site orbits
+        drops accordingly.
 
         Parameters
         ----------
         symprec_range : tuple[float, ...]
-            Symmetry tolerances (Ångstrom) to try. The tolerance giving the
-            highest space group number wins; ties are broken towards the
-            tightest (smallest) tolerance.
+            Symmetry tolerances (Ångstrom) to evaluate.
+        angle_tolerance : float
+            Angle tolerance (degrees) passed to
+            [pymatgen.symmetry.analyzer.SpacegroupAnalyzer][].
+        background_level : float
+            Fraction of the maximum density used as the segmentation floor.
+        **find_peaks_kwargs : dict
+            Passed through to [gemdat.volume.Volume.find_peaks][].
+
+        Returns
+        -------
+        list[SymmetryLevel]
+            One [SymmetryLevel][gemdat.crystallizer.SymmetryLevel] per symprec,
+            ordered by symprec ascending. A tolerance at which the symmetry
+            search raised is kept with `None` fields and its `error` set.
+        """
+        geometry, _ = self._geometry_and_occupancies(
+            background_level=background_level, **find_peaks_kwargs
+        )
+        return [
+            _build_symmetry_level(geometry, symprec, angle_tolerance)
+            for symprec in sorted(symprec_range)
+        ]
+
+    def crystallize(
+        self,
+        *,
+        symprec: float | None = None,
+        target_spacegroup: int | str | None = None,
+        symprec_range: tuple[float, ...] = (0.01, 0.05, 0.1, 0.2, 0.3, 0.5),
+        angle_tolerance: float = 5.0,
+        background_level: float = 0.1,
+        **find_peaks_kwargs,
+    ) -> CrystallizerResult:
+        """Build the full structure and fit a space group.
+
+        By default the symmetry tolerance is swept over `symprec_range` and the
+        tolerance giving the highest space group number wins (ties broken
+        towards the tightest tolerance). This can be overridden:
+
+        - pass `symprec` to skip the sweep and fit at exactly that tolerance
+          ("set it if you are sure what it should be");
+        - pass `target_spacegroup` to pick the tightest tolerance in the sweep
+          that yields that space group.
+
+        Parameters
+        ----------
+        symprec : float | None
+            If given, fit at exactly this tolerance (Ångstrom) and skip the
+            sweep. `result.symprec` equals this value. Raises `ValueError` if
+            the symmetry search fails at this tolerance (no silent fallback).
+            Mutually exclusive with `target_spacegroup`.
+        target_spacegroup : int | str | None
+            If given, select the tightest (smallest) symprec in `symprec_range`
+            whose fit matches this space group. An `int` is matched against the
+            international number, a `str` against the Hermann-Mauguin symbol
+            (case-insensitive, whitespace-insensitive). Raises `ValueError`
+            listing what was found at each symprec if nothing matches. Mutually
+            exclusive with `symprec`.
+        symprec_range : tuple[float, ...]
+            Symmetry tolerances (Ångstrom) to try when sweeping. The tolerance
+            giving the highest space group number wins; ties are broken towards
+            the tightest (smallest) tolerance.
         angle_tolerance : float
             Angle tolerance (degrees) passed to
             [pymatgen.symmetry.analyzer.SpacegroupAnalyzer][].
@@ -239,29 +461,75 @@ class Crystallizer:
         Returns
         -------
         result : CrystallizerResult
-            The symmetrized structure and the fitted space group.
+            The symmetrized structure and the fitted space group. When a sweep
+            was run, `result.ladder` holds the full symmetry ladder and
+            `result.candidates` the distinct space groups found, ranked by
+            number descending.
+
+        Raises
+        ------
+        ValueError
+            If `symprec` and `target_spacegroup` are both given; if the fit
+            fails at an explicit `symprec`; if no `target_spacegroup` match is
+            found; or if no symprec in the sweep yields a symmetry.
         """
+        if symprec is not None and target_spacegroup is not None:
+            raise ValueError(
+                'Pass either `symprec` or `target_spacegroup`, not both '
+                '(they are contradictory).'
+            )
+
         geometry, occupancies = self._geometry_and_occupancies(
             background_level=background_level, **find_peaks_kwargs
         )
 
-        best_symprec = None
-        best_number = 0
-        for symprec in symprec_range:
-            try:
-                number = SpacegroupAnalyzer(
-                    geometry, symprec=symprec, angle_tolerance=angle_tolerance
-                ).get_space_group_number()
-            except Exception:
-                continue
-            if number > best_number:
-                best_number = number
-                best_symprec = symprec
+        ladder: list[SymmetryLevel] | None = None
+        candidates: list[SymmetryLevel] | None = None
 
-        if best_symprec is None:
-            raise ValueError(
-                'Could not determine symmetry for any of the given symprec values.'
+        if symprec is not None:
+            level = _build_symmetry_level(geometry, symprec, angle_tolerance)
+            if level.spacegroup_number is None:
+                raise ValueError(
+                    f'Could not determine symmetry at symprec={symprec}: {level.error}'
+                )
+            best_symprec = symprec
+        else:
+            ladder = [
+                _build_symmetry_level(geometry, sp, angle_tolerance)
+                for sp in sorted(symprec_range)
+            ]
+            found = [lvl for lvl in ladder if lvl.spacegroup_number is not None]
+            if not found:
+                raise ValueError(
+                    'Could not determine symmetry for any of the given symprec values.'
+                )
+
+            # Distinct space groups, tightest symprec each (ladder is
+            # symprec-ascending), ranked by number descending -> "Top-X".
+            seen: dict[int, SymmetryLevel] = {}
+            for lvl in found:
+                assert lvl.spacegroup_number is not None
+                seen.setdefault(lvl.spacegroup_number, lvl)
+            candidates = sorted(
+                seen.values(),
+                key=lambda lvl: lvl.spacegroup_number or 0,
+                reverse=True,
             )
+
+            if target_spacegroup is not None:
+                match = _match_target_spacegroup(found, target_spacegroup)
+                if match is None:
+                    raise ValueError(
+                        f'No symprec in the sweep produced space group '
+                        f'{target_spacegroup!r}. Found:\n' + _format_ladder(ladder)
+                    )
+                best_symprec = match.symprec
+            else:
+                best = max(
+                    found,
+                    key=lambda lvl: (lvl.spacegroup_number or 0, -lvl.symprec),
+                )
+                best_symprec = best.symprec
 
         sga = SpacegroupAnalyzer(
             geometry, symprec=best_symprec, angle_tolerance=angle_tolerance
@@ -290,6 +558,8 @@ class Crystallizer:
             spacegroup_symbol=sga.get_space_group_symbol(),
             spacegroup_number=sga.get_space_group_number(),
             symprec=best_symprec,
+            ladder=ladder,
+            candidates=candidates,
         )
 
     def to_cif(self, filename: Path | str, **kwargs) -> CrystallizerResult:

--- a/src/gemdat/crystallizer.py
+++ b/src/gemdat/crystallizer.py
@@ -11,6 +11,7 @@ import numpy as np
 from pymatgen.core import Structure
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 
+from .caching import weak_lru_cache
 from .io import write_cif
 from .symmetry import SymmetryAnalyzer, SymmetryLevel, SymmetryRanking
 from .utils import require_constant_lattice
@@ -52,20 +53,34 @@ class CrystallizerResult:
     symprec: float
     ranking: SymmetryRanking | None = None
 
+    def _require_ranking(self) -> SymmetryRanking:
+        """Return the ranking, or explain why there is none."""
+        if self.ranking is None:
+            raise ValueError(
+                'This result has no symmetry ranking because `symprec` was set '
+                'explicitly. Call `Crystallizer.symmetry_ranking()` instead.'
+            )
+        return self.ranking
+
     @property
-    def candidates(self) -> list[SymmetryLevel] | None:
+    def candidates(self) -> list[SymmetryLevel]:
         """The distinct space groups found across the sweep ("Top-X").
 
         Returns
         -------
-        list[SymmetryLevel] | None
+        list[SymmetryLevel]
             One level per space group, ranked by space-group number
             descending, each represented by the tightest symprec that produced
-            it. `None` when no sweep was run.
+            it.
+
+        Raises
+        ------
+        ValueError
+            If this result carries no ranking (i.e. `symprec` was set
+            explicitly, so no sweep was performed). Test `result.ranking is
+            None` to tell the two cases apart.
         """
-        if self.ranking is None:
-            return None
-        return self.ranking.candidates
+        return self._require_ranking().candidates
 
     def format_ranking(self) -> str:
         """Return the symmetry ranking as a readable fixed-width table.
@@ -82,12 +97,7 @@ class CrystallizerResult:
             If this result carries no ranking (i.e. `symprec` was set
             explicitly, so no sweep was performed).
         """
-        if self.ranking is None:
-            raise ValueError(
-                'This result has no symmetry ranking because `symprec` was set '
-                'explicitly. Call `Crystallizer.symmetry_ranking()` instead.'
-            )
-        return self.ranking.format()
+        return self._require_ranking().format()
 
 
 class Crystallizer:
@@ -235,7 +245,41 @@ class Crystallizer:
         separately, aligned to the structure's site order (framework
         sites are 1.0), so they can be averaged over the symmetry-
         equivalent classes afterwards.
+
+        Extracting the density peaks dominates the cost of everything
+        downstream, and the same geometry is reused by repeated
+        `crystallize`/`symmetry_ranking`/`to_cif` calls, so the result
+        is cached per set of arguments. Arguments that cannot be hashed
+        (e.g. an explicit `peaks` array) simply bypass the cache.
         """
+        key = tuple(sorted(find_peaks_kwargs.items()))
+        try:
+            hash(key)
+        except TypeError:
+            return self._compute_geometry_and_occupancies(
+                background_level=background_level, **find_peaks_kwargs
+            )
+        return self._cached_geometry_and_occupancies(background_level, key)
+
+    @weak_lru_cache()
+    def _cached_geometry_and_occupancies(
+        self,
+        background_level: float,
+        find_peaks_items: tuple[tuple[str, object], ...],
+    ) -> tuple[Structure, np.ndarray]:
+        """Cached wrapper around `_compute_geometry_and_occupancies`, taking
+        the keyword arguments in a hashable form."""
+        return self._compute_geometry_and_occupancies(
+            background_level=background_level, **dict(find_peaks_items)
+        )
+
+    def _compute_geometry_and_occupancies(
+        self,
+        *,
+        background_level: float = 0.1,
+        **find_peaks_kwargs,
+    ) -> tuple[Structure, np.ndarray]:
+        """Do the work for `_geometry_and_occupancies`."""
         framework = self.framework()
         mobile = self.mobile_sites(background_level=background_level, **find_peaks_kwargs)
 
@@ -262,9 +306,9 @@ class Crystallizer:
         self,
         *,
         symprec_range: tuple[float, ...] | None = None,
-        symprec_min: float = 0.01,
-        symprec_max: float = 0.5,
-        n_samples: int = 40,
+        symprec_min: float | None = None,
+        symprec_max: float | None = None,
+        n_samples: int | None = None,
         angle_tolerance: float = 5.0,
         background_level: float = 0.1,
         **find_peaks_kwargs,
@@ -290,16 +334,19 @@ class Crystallizer:
         symprec_range : tuple[float, ...] | None
             If given, evaluate exactly these tolerances (Ångstrom) and skip
             the automatic scan; the result then has one level per tolerance,
-            including duplicated space groups.
-        symprec_min : float
-            Tightest tolerance (Ångstrom) of the automatic scan.
-        symprec_max : float
-            Loosest tolerance (Ångstrom) of the automatic scan. Beyond ~0.5 Å
-            the fit says more about the tolerance than about the structure.
-        n_samples : int
-            Number of log-spaced tolerances in the scan. A space group holding
-            over a window narrower than the grid spacing can be missed; raise
-            this to scan more finely.
+            including duplicated space groups. Mutually exclusive with the
+            scan settings below.
+        symprec_min : float | None
+            Tightest tolerance (Ångstrom) of the automatic scan, default
+            0.01 Å.
+        symprec_max : float | None
+            Loosest tolerance (Ångstrom) of the automatic scan, default 0.5 Å.
+            Beyond ~0.5 Å the fit says more about the tolerance than about the
+            structure.
+        n_samples : int | None
+            Number of log-spaced tolerances in the scan, default 40. A space
+            group holding over a window narrower than the grid spacing can be
+            missed; raise this to scan more finely.
         angle_tolerance : float
             Angle tolerance (degrees) passed to
             [pymatgen.symmetry.analyzer.SpacegroupAnalyzer][].
@@ -318,14 +365,18 @@ class Crystallizer:
             `symprec_range`: one per tolerance, ordered by symprec ascending,
             where a tolerance at which the symmetry search raised is kept with
             `None` fields and its `error` set.
+
+        Raises
+        ------
+        ValueError
+            If `symprec_range` is combined with any of the scan settings.
         """
         geometry, _ = self._geometry_and_occupancies(
             background_level=background_level, **find_peaks_kwargs
         )
         analyzer = SymmetryAnalyzer(geometry, angle_tolerance=angle_tolerance)
-        if symprec_range is not None:
-            return analyzer.levels(symprec_range)
-        return analyzer.scan(
+        return analyzer.rank(
+            symprec_range=symprec_range,
             symprec_min=symprec_min,
             symprec_max=symprec_max,
             n_samples=n_samples,
@@ -337,9 +388,9 @@ class Crystallizer:
         symprec: float | None = None,
         target_spacegroup: int | str | None = None,
         symprec_range: tuple[float, ...] | None = None,
-        symprec_min: float = 0.01,
-        symprec_max: float = 0.5,
-        n_samples: int = 40,
+        symprec_min: float | None = None,
+        symprec_max: float | None = None,
+        n_samples: int | None = None,
         angle_tolerance: float = 5.0,
         background_level: float = 0.1,
         **find_peaks_kwargs,
@@ -366,7 +417,8 @@ class Crystallizer:
             If given, fit at exactly this tolerance (Ångstrom) and skip the
             sweep. `result.symprec` equals this value. Raises `ValueError` if
             the symmetry search fails at this tolerance (no silent fallback).
-            Mutually exclusive with `target_spacegroup`.
+            Mutually exclusive with `target_spacegroup` and with every setting
+            that configures the sweep.
         target_spacegroup : int | str | None
             If given, select the tightest (smallest) symprec in the sweep whose
             fit matches this space group. An `int` is matched against the
@@ -378,13 +430,16 @@ class Crystallizer:
             If given, sweep exactly these tolerances (Ångstrom) instead of
             scanning `symprec_min`..`symprec_max` automatically. The tolerance
             giving the highest space group number wins either way; ties are
-            broken towards the tightest (smallest) tolerance.
-        symprec_min : float
-            Tightest tolerance (Ångstrom) of the automatic scan.
-        symprec_max : float
-            Loosest tolerance (Ångstrom) of the automatic scan.
-        n_samples : int
-            Number of log-spaced tolerances in the automatic scan.
+            broken towards the tightest (smallest) tolerance. Mutually
+            exclusive with the scan settings below.
+        symprec_min : float | None
+            Tightest tolerance (Ångstrom) of the automatic scan, default
+            0.01 Å.
+        symprec_max : float | None
+            Loosest tolerance (Ångstrom) of the automatic scan, default 0.5 Å.
+        n_samples : int | None
+            Number of log-spaced tolerances in the automatic scan, default
+            40.
         angle_tolerance : float
             Angle tolerance (degrees) passed to
             [pymatgen.symmetry.analyzer.SpacegroupAnalyzer][].
@@ -404,15 +459,29 @@ class Crystallizer:
         Raises
         ------
         ValueError
-            If `symprec` and `target_spacegroup` are both given; if the fit
-            fails at an explicit `symprec`; if no `target_spacegroup` match is
-            found; or if no symprec in the sweep yields a symmetry.
+            If `symprec` is combined with any argument that configures the
+            sweep; if the fit fails at an explicit `symprec`; if no
+            `target_spacegroup` match is found; or if no symprec in the sweep
+            yields a symmetry.
         """
-        if symprec is not None and target_spacegroup is not None:
-            raise ValueError(
-                'Pass either `symprec` or `target_spacegroup`, not both '
-                '(they are contradictory).'
-            )
+        if symprec is not None:
+            conflicting = [
+                name
+                for name, value in (
+                    ('target_spacegroup', target_spacegroup),
+                    ('symprec_range', symprec_range),
+                    ('symprec_min', symprec_min),
+                    ('symprec_max', symprec_max),
+                    ('n_samples', n_samples),
+                )
+                if value is not None
+            ]
+            if conflicting:
+                listed = ', '.join(f'`{name}`' for name in conflicting)
+                raise ValueError(
+                    f'`symprec` pins the tolerance, so it cannot be combined with '
+                    f'{listed}; those select a tolerance from a sweep.'
+                )
 
         geometry, occupancies = self._geometry_and_occupancies(
             background_level=background_level, **find_peaks_kwargs
@@ -422,21 +491,14 @@ class Crystallizer:
         ranking: SymmetryRanking | None = None
 
         if symprec is not None:
-            level = analyzer.level(symprec)
-            if level.spacegroup_number is None:
-                raise ValueError(
-                    f'Could not determine symmetry at symprec={symprec}: {level.error}'
-                )
             best_symprec = symprec
         else:
-            if symprec_range is not None:
-                ranking = analyzer.levels(symprec_range)
-            else:
-                ranking = analyzer.scan(
-                    symprec_min=symprec_min,
-                    symprec_max=symprec_max,
-                    n_samples=n_samples,
-                )
+            ranking = analyzer.rank(
+                symprec_range=symprec_range,
+                symprec_min=symprec_min,
+                symprec_max=symprec_max,
+                n_samples=n_samples,
+            )
 
             if target_spacegroup is not None:
                 match = ranking.match(target_spacegroup)
@@ -450,10 +512,19 @@ class Crystallizer:
                 # Raises if no tolerance in the sweep yielded a symmetry.
                 best_symprec = ranking.best().symprec
 
-        sga = SpacegroupAnalyzer(
-            geometry, symprec=best_symprec, angle_tolerance=angle_tolerance
-        )
-        symmetrized = sga.get_symmetrized_structure()
+        # The sweep already knows this tolerance works; an explicit `symprec`
+        # is only checked here, so that it is fitted exactly once either way.
+        try:
+            sga = SpacegroupAnalyzer(
+                geometry, symprec=best_symprec, angle_tolerance=angle_tolerance
+            )
+            symmetrized = sga.get_symmetrized_structure()
+            spacegroup_symbol = sga.get_space_group_symbol()
+            spacegroup_number = sga.get_space_group_number()
+        except Exception as exc:
+            raise ValueError(
+                f'Could not determine symmetry at symprec={best_symprec}: {exc}'
+            ) from exc
 
         # Average occupancy within each symmetry-equivalent class so that
         # equivalent sites are truly equivalent before the cif is written.
@@ -474,8 +545,8 @@ class Crystallizer:
 
         return CrystallizerResult(
             structure=structure,
-            spacegroup_symbol=sga.get_space_group_symbol(),
-            spacegroup_number=sga.get_space_group_number(),
+            spacegroup_symbol=spacegroup_symbol,
+            spacegroup_number=spacegroup_number,
             symprec=best_symprec,
             ranking=ranking,
         )

--- a/src/gemdat/crystallizer.py
+++ b/src/gemdat/crystallizer.py
@@ -17,6 +17,7 @@ from .symmetry import SymmetryAnalyzer, SymmetryLevel, SymmetryRanking
 from .utils import require_constant_lattice
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
     from pathlib import Path
 
     from .trajectory import Trajectory
@@ -24,8 +25,12 @@ if TYPE_CHECKING:
 
 @dataclass
 class CrystallizerResult:
-    """Result of [crystallize][gemdat.crystallizer.Crystallizer.crystallize].
+    """Dataclass of a crystallized structure at a single symmetry tolerance.
 
+    Returned by [Crystallizer.crystallize][gemdat.crystallizer.Crystallizer.crystallize],
+    [Crystallizer.crystallize_at][gemdat.crystallizer.Crystallizer.crystallize_at]
+    and
+    [CrystallizerScan][gemdat.crystallizer.CrystallizerScan].
     Parameters
     ----------
     structure : Structure
@@ -38,51 +43,149 @@ class CrystallizerResult:
         International number of the fitted space group.
     symprec : float
         Symmetry tolerance (in Ångstrom) that produced the fit.
-    ranking : SymmetryRanking | None
-        The full symmetry ranking: one
-        [SymmetryLevel][gemdat.symmetry.SymmetryLevel] per distinct space
-        group found by the automatic scan, ordered by required `deviation`
-        ascending, or one per tolerance (symprec ascending) when
-        `symprec_range` was given explicitly. `None` when `symprec` was set
-        explicitly and no sweep was run.
     """
 
     structure: Structure
     spacegroup_symbol: str
     spacegroup_number: int
     symprec: float
-    ranking: SymmetryRanking | None = None
 
-    def _require_ranking(self) -> SymmetryRanking:
-        """Return the ranking, or explain why there is none."""
-        if self.ranking is None:
-            raise ValueError(
-                'This result has no symmetry ranking because `symprec` was set '
-                'explicitly. Call `Crystallizer.symmetry_ranking()` instead.'
-            )
-        return self.ranking
+    def to_cif(self, filename: Path | str) -> None:
+        """Write this structure to a cif file, with its symmetry.
+
+        Parameters
+        ----------
+        filename : Path | str
+            Output filename (a `.cif` suffix is enforced).
+        """
+        write_cif(self.structure, filename, symprec=self.symprec)
+
+
+def _fit(
+    geometry: Structure,
+    occupancies: np.ndarray,
+    *,
+    symprec: float,
+    angle_tolerance: float,
+) -> CrystallizerResult:
+    """Fit `geometry` at one tolerance and assemble the result.
+
+    Parameters
+    ----------
+    geometry : Structure
+        Geometry-only structure (all sites at full occupancy).
+    occupancies : np.ndarray
+        Occupancy per site, aligned to `geometry`'s site order.
+    symprec : float
+        Symmetry tolerance (Ångstrom).
+    angle_tolerance : float
+        Angle tolerance (degrees).
+
+    Returns
+    -------
+    CrystallizerResult
+    """
+    try:
+        sga = SpacegroupAnalyzer(geometry, symprec=symprec, angle_tolerance=angle_tolerance)
+        symmetrized = sga.get_symmetrized_structure()
+        spacegroup_symbol = sga.get_space_group_symbol()
+        spacegroup_number = sga.get_space_group_number()
+    except Exception as exc:
+        raise ValueError(f'Could not determine symmetry at symprec={symprec}: {exc}') from exc
+
+    # Average occupancy within each symmetry-equivalent class so that
+    # equivalent sites are truly equivalent before the cif is written.
+    # `equivalent_indices` indexes into `geometry`'s site order, which is how
+    # `occupancies` is aligned.
+    new_species: list[dict] = [{} for _ in range(len(symmetrized))]
+    for group in symmetrized.equivalent_indices:
+        symbol = symmetrized[group[0]].specie.symbol
+        avg_occupancy = float(np.mean([occupancies[i] for i in group]))
+        for i in group:
+            new_species[i] = {symbol: avg_occupancy}
+
+    structure = Structure(
+        lattice=symmetrized.lattice,
+        species=new_species,
+        coords=[site.frac_coords for site in symmetrized],
+    )
+
+    return CrystallizerResult(
+        structure=structure,
+        spacegroup_symbol=spacegroup_symbol,
+        spacegroup_number=spacegroup_number,
+        symprec=symprec,
+    )
+
+
+class CrystallizerScan:
+    """A reconstructed geometry together with the space groups it can adopt.
+
+    Returned by [Crystallizer.scan][gemdat.crystallizer.Crystallizer.scan] and
+    [Crystallizer.scan_at][gemdat.crystallizer.Crystallizer.scan_at]. The
+    expensive parts — extracting the density peaks and sweeping the symmetry
+    tolerance — happen once, when the scan is made; picking a space group off
+    it afterwards is a single symmetry fit:
+
+    ```python
+    scan = crystallizer.scan()
+    print(scan.format())
+
+    scan.best().to_cif('crystallized.cif')
+    scan.at_spacegroup('Cm').to_cif('monoclinic.cif')
+    for level in scan.candidates:
+        scan.at_level(level).to_cif(f'{level.spacegroup_number}.cif')
+    ```
+    """
+
+    def __init__(
+        self,
+        *,
+        geometry: Structure,
+        occupancies: np.ndarray,
+        ranking: SymmetryRanking,
+        angle_tolerance: float = 5.0,
+    ):
+        """Set up the scan.
+
+        Built by [Crystallizer][gemdat.crystallizer.Crystallizer], not directly.
+
+        Parameters
+        ----------
+        geometry : Structure
+            Geometry-only structure that was fitted (framework + mobile sites,
+            all at full occupancy).
+        occupancies : np.ndarray
+            Occupancy per site, aligned to `geometry`'s site order.
+        ranking : SymmetryRanking
+            The space groups found for `geometry`.
+        angle_tolerance : float
+            Angle tolerance (degrees) the ranking was produced with, reused by
+            every fit taken off this scan.
+        """
+        self.geometry = geometry
+        self.occupancies = occupancies
+        self.ranking = ranking
+        self.angle_tolerance = angle_tolerance
+
+    def __repr__(self) -> str:
+        return f'{type(self).__name__}({len(self.geometry)} sites, {self.ranking!r})'
 
     @property
     def candidates(self) -> list[SymmetryLevel]:
-        """The distinct space groups found across the sweep ("Top-X").
+        """The distinct space groups found ("Top-X").
 
         Returns
         -------
         list[SymmetryLevel]
             One level per space group, ranked by space-group number
             descending, each represented by the tightest symprec that produced
-            it.
-
-        Raises
-        ------
-        ValueError
-            If this result carries no ranking (i.e. `symprec` was set
-            explicitly, so no sweep was performed). Test `result.ranking is
-            None` to tell the two cases apart.
+            it. See
+            [SymmetryRanking.candidates][gemdat.symmetry.SymmetryRanking.candidates].
         """
-        return self._require_ranking().candidates
+        return self.ranking.candidates
 
-    def format_ranking(self) -> str:
+    def format(self) -> str:
         """Return the symmetry ranking as a readable fixed-width table.
 
         See [SymmetryRanking.format][gemdat.symmetry.SymmetryRanking.format].
@@ -90,14 +193,117 @@ class CrystallizerResult:
         Returns
         -------
         str
+        """
+        return self.ranking.format()
+
+    def best(self) -> CrystallizerResult:
+        """Crystallize the highest space group found.
+
+        Ties are broken towards the tightest tolerance.
+
+        Returns
+        -------
+        CrystallizerResult
 
         Raises
         ------
         ValueError
-            If this result carries no ranking (i.e. `symprec` was set
-            explicitly, so no sweep was performed).
+            If no tolerance in the scan yielded a symmetry.
         """
-        return self._require_ranking().format()
+        return self.at(self.ranking.best().symprec)
+
+    def at(self, symprec: float) -> CrystallizerResult:
+        """Crystallize at exactly this tolerance.
+
+        The tolerance need not be one the scan visited.
+
+        Parameters
+        ----------
+        symprec : float
+            Symmetry tolerance (Ångstrom) to fit at.
+
+        Returns
+        -------
+        CrystallizerResult
+
+        Raises
+        ------
+        ValueError
+            If the symmetry search fails at this tolerance.
+        """
+        return _fit(
+            self.geometry,
+            self.occupancies,
+            symprec=symprec,
+            angle_tolerance=self.angle_tolerance,
+        )
+
+    def at_level(self, level: SymmetryLevel) -> CrystallizerResult:
+        """Crystallize the space group of one row of this scan's ranking.
+
+        The level records the tolerance its space group was found at, so a
+        group picked off the ranking table is crystallized without translating
+        it back into a tolerance.
+
+        Parameters
+        ----------
+        level : SymmetryLevel
+            A row of `self.ranking`, e.g. from
+            [candidates][gemdat.crystallizer.CrystallizerScan.candidates].
+
+        Returns
+        -------
+        CrystallizerResult
+
+        Raises
+        ------
+        ValueError
+            If the level is not one of this scan's, or if it found no space
+            group.
+        """
+        if level not in self.ranking:
+            raise ValueError(
+                'The given level is not part of this scan. A level fixes a '
+                'tolerance for the geometry it was ranked on, so it can only be '
+                'crystallized by the scan that produced it.'
+            )
+        if level.spacegroup_number is None:
+            raise ValueError(
+                f'The given level found no space group at '
+                f'symprec={level.symprec:g} ({level.error}), so there is '
+                f'nothing to crystallize at its tolerance.'
+            )
+        return self.at(level.symprec)
+
+    def at_spacegroup(self, spacegroup: int | str) -> CrystallizerResult:
+        """Crystallize the space group you name.
+
+        The tightest tolerance in the scan that reaches it is used.
+
+        Parameters
+        ----------
+        spacegroup : int | str
+            An `int` is matched against the international number, a `str`
+            against the Hermann-Mauguin symbol (case-insensitive,
+            whitespace-insensitive).
+
+        Returns
+        -------
+        CrystallizerResult
+
+        Raises
+        ------
+        ValueError
+            If no tolerance in the scan produces this space group; the message
+            lists what was found instead.
+        """
+        match = self.ranking.match(spacegroup)
+        if match is None:
+            raise ValueError(
+                f'No symprec in this scan produced space group '
+                f'{spacegroup!r}. Found:\n' + self.format()
+            )
+        return self.at(match.symprec)
 
 
 class Crystallizer:
@@ -105,8 +311,21 @@ class Crystallizer:
 
     The pipeline is: the mobile species density is turned into candidate sites
     with partial occupancies, these are combined with the time-averaged static
-    host framework, and the highest crystal symmetry consistent with the
-    resulting structure is fitted. The result can be written to a cif file.
+    host framework, and the crystal symmetry of the resulting structure is
+    fitted. The result can be written to a cif file.
+
+    Which symmetry you get depends on the tolerance it is fitted at, so each
+    way of choosing that tolerance is its own entry point:
+
+    - [crystallize][gemdat.crystallizer.Crystallizer.crystallize] (and
+      [to_cif][gemdat.crystallizer.Crystallizer.to_cif]) scan the tolerance and
+      take the highest space group found — the default answer;
+    - [scan][gemdat.crystallizer.Crystallizer.scan] /
+      [scan_at][gemdat.crystallizer.Crystallizer.scan_at] hand back the whole
+      [CrystallizerScan][gemdat.crystallizer.CrystallizerScan], which reports
+      every space group the geometry reaches and crystallizes any of them;
+    - [crystallize_at][gemdat.crystallizer.Crystallizer.crystallize_at] fits a
+      tolerance you already know, without scanning.
     """
 
     def __init__(
@@ -248,9 +467,9 @@ class Crystallizer:
 
         Extracting the density peaks dominates the cost of everything
         downstream, and the same geometry is reused by repeated
-        `crystallize`/`symmetry_ranking`/`to_cif` calls, so the result
-        is cached per set of arguments. Arguments that cannot be hashed
-        (e.g. an explicit `peaks` array) simply bypass the cache.
+        `crystallize`/`scan`/`to_cif` calls, so the result is cached per
+        set of arguments. Arguments that cannot be hashed (e.g. an
+        explicit `peaks` array) simply bypass the cache.
         """
         key = tuple(sorted(find_peaks_kwargs.items()))
         try:
@@ -302,46 +521,48 @@ class Crystallizer:
         )
         return geometry, np.array(occupancies)
 
-    def symmetry_ranking(
+    def scan(
         self,
         *,
-        symprec_range: tuple[float, ...] | None = None,
         symprec_min: float | None = None,
         symprec_max: float | None = None,
         n_samples: int | None = None,
         angle_tolerance: float = 5.0,
         background_level: float = 0.1,
         **find_peaks_kwargs,
-    ) -> SymmetryRanking:
-        """Rank the space groups the reconstructed geometry can adopt by the
-        symmetry tolerance each one requires.
+    ) -> CrystallizerScan:
+        """Reconstruct the geometry and rank the space groups it can adopt.
 
-        This shows which sub-symmetries appear and at what precision (in
-        Ångstrom): loosening `symprec` typically climbs from P1 towards the
+        This shows which sub-symmetries the data supports and at what precision
+        (in Ångstrom): loosening `symprec` typically climbs from P1 towards the
         parent space group, and the number of symmetry-distinct site orbits
         drops accordingly.
 
-        By default the tolerances are found automatically: the range is
-        scanned for the space groups the geometry can adopt, and for each one
-        the tolerance it actually requires is measured (`deviation`, in
-        Ångstrom, and `angle_deviation`, in degrees) rather than read off the
-        sampling grid. The result is one row per space group instead of one
-        row per hand-picked tolerance. Pass `symprec_range` to evaluate a
-        fixed list of tolerances instead.
+        The tolerances are found automatically: the range is scanned for the
+        space groups the geometry can adopt, and for each one the tolerance it
+        actually requires is measured (`deviation`, in Ångstrom, and
+        `angle_deviation`, in degrees) rather than read off the sampling grid.
+        The ranking therefore has one row per space group. Pass a fixed list of
+        tolerances to [scan_at][gemdat.crystallizer.Crystallizer.scan_at]
+        instead to get one row per tolerance.
+
+        The returned scan crystallizes any of the space groups it found, so
+        this is the way to write out more than one fit:
+
+        ```python
+        scan = crystallizer.scan()
+        print(scan.format())
+        scan.best().to_cif('crystallized.cif')
+        scan.at_spacegroup(217).to_cif('cubic.cif')
+        ```
 
         Parameters
         ----------
-        symprec_range : tuple[float, ...] | None
-            If given, evaluate exactly these tolerances (Ångstrom) and skip
-            the automatic scan; the result then has one level per tolerance,
-            including duplicated space groups. Mutually exclusive with the
-            scan settings below.
         symprec_min : float | None
-            Tightest tolerance (Ångstrom) of the automatic scan, default
-            0.01 Å.
+            Tightest tolerance (Ångstrom) of the scan, default 0.01 Å.
         symprec_max : float | None
-            Loosest tolerance (Ångstrom) of the automatic scan, default 0.5 Å.
-            Beyond ~0.5 Å the fit says more about the tolerance than about the
+            Loosest tolerance (Ångstrom) of the scan, default 0.5 Å. Beyond
+            ~0.5 Å the fit says more about the tolerance than about the
             structure.
         n_samples : int | None
             Number of log-spaced tolerances in the scan, default 40. A space
@@ -357,89 +578,127 @@ class Crystallizer:
 
         Returns
         -------
-        SymmetryRanking
-            From the automatic scan: one
+        CrystallizerScan
+            The reconstructed geometry and its ranking: one
             [SymmetryLevel][gemdat.symmetry.SymmetryLevel] per distinct space
             group, ordered by `deviation` ascending, with `deviation`,
-            `angle_deviation` and `n_observed` set. From an explicit
-            `symprec_range`: one per tolerance, ordered by symprec ascending,
-            where a tolerance at which the symmetry search raised is kept with
-            `None` fields and its `error` set.
-
-        Raises
-        ------
-        ValueError
-            If `symprec_range` is combined with any of the scan settings.
+            `angle_deviation` and `n_observed` set.
         """
-        geometry, _ = self._geometry_and_occupancies(
-            background_level=background_level, **find_peaks_kwargs
+        geometry, occupancies, analyzer = self._geometry_and_analyzer(
+            angle_tolerance=angle_tolerance,
+            background_level=background_level,
+            **find_peaks_kwargs,
         )
-        analyzer = SymmetryAnalyzer(geometry, angle_tolerance=angle_tolerance)
-        return analyzer.rank(
-            symprec_range=symprec_range,
+        ranking = analyzer.rank(
             symprec_min=symprec_min,
             symprec_max=symprec_max,
             n_samples=n_samples,
         )
+        return CrystallizerScan(
+            geometry=geometry,
+            occupancies=occupancies,
+            ranking=ranking,
+            angle_tolerance=angle_tolerance,
+        )
 
-    def crystallize(
+    def scan_at(
         self,
+        symprecs: Iterable[float],
         *,
-        symprec: float | None = None,
-        target_spacegroup: int | str | None = None,
-        symprec_range: tuple[float, ...] | None = None,
-        symprec_min: float | None = None,
-        symprec_max: float | None = None,
-        n_samples: int | None = None,
+        angle_tolerance: float = 5.0,
+        background_level: float = 0.1,
+        **find_peaks_kwargs,
+    ) -> CrystallizerScan:
+        """Reconstruct the geometry and fit it at each of the given tolerances.
+
+        Where [scan][gemdat.crystallizer.Crystallizer.scan] finds the
+        tolerances itself and reports one row per space group, this reports one
+        row per tolerance handed to it, including repeated space groups. The
+        deviations are not measured.
+
+        Parameters
+        ----------
+        symprecs : Iterable[float]
+            Tolerances (Ångstrom) to evaluate.
+        angle_tolerance : float
+            Angle tolerance (degrees) passed to
+            [pymatgen.symmetry.analyzer.SpacegroupAnalyzer][].
+        background_level : float
+            Fraction of the maximum density used as the segmentation floor.
+        **find_peaks_kwargs : dict
+            Passed through to [gemdat.volume.Volume.find_peaks][].
+
+        Returns
+        -------
+        CrystallizerScan
+            The reconstructed geometry and its ranking: one
+            [SymmetryLevel][gemdat.symmetry.SymmetryLevel] per tolerance,
+            ordered by symprec ascending, where a tolerance at which the
+            symmetry search raised is kept with `None` fields and its `error`
+            set.
+        """
+        geometry, occupancies, analyzer = self._geometry_and_analyzer(
+            angle_tolerance=angle_tolerance,
+            background_level=background_level,
+            **find_peaks_kwargs,
+        )
+        return CrystallizerScan(
+            geometry=geometry,
+            occupancies=occupancies,
+            ranking=analyzer.rank_at(symprecs),
+            angle_tolerance=angle_tolerance,
+        )
+
+    def crystallize(self, **kwargs) -> CrystallizerResult:
+        """Build the full structure and fit the highest space group it
+        supports.
+
+        This is [scan][gemdat.crystallizer.Crystallizer.scan] followed by
+        [CrystallizerScan.best][gemdat.crystallizer.CrystallizerScan.best]: the
+        symmetry tolerance is scanned, and the highest space group number found
+        wins (ties broken towards the tightest tolerance). Keep the
+        [scan][gemdat.crystallizer.Crystallizer.scan] itself to see the
+        alternatives, or to crystallize one of them;
+        [crystallize_at][gemdat.crystallizer.Crystallizer.crystallize_at] fits
+        a tolerance you already know without scanning at all.
+
+        Parameters
+        ----------
+        **kwargs : dict
+            Passed through to [scan][gemdat.crystallizer.Crystallizer.scan],
+            e.g. `symprec_min=`, `symprec_max=`, `n_samples=`,
+            `angle_tolerance=`, `background_level=` and the peak-finding
+            arguments.
+
+        Returns
+        -------
+        result : CrystallizerResult
+            The symmetrized structure and the fitted space group.
+
+        Raises
+        ------
+        ValueError
+            If no symprec in the scan yields a symmetry.
+        """
+        return self.scan(**kwargs).best()
+
+    def crystallize_at(
+        self,
+        symprec: float,
+        *,
         angle_tolerance: float = 5.0,
         background_level: float = 0.1,
         **find_peaks_kwargs,
     ) -> CrystallizerResult:
-        """Build the full structure and fit a space group.
+        """Build the full structure and fit it at exactly this tolerance.
 
-        By default the symmetry tolerance is swept automatically (see
-        [symmetry_ranking][gemdat.crystallizer.Crystallizer.symmetry_ranking]):
-        every space group the geometry recovered between `symprec_min` and
-        `symprec_max` is found, together with the deviation it requires, and
-        the highest space group number wins (ties broken towards the tightest
-        tolerance). This can be overridden:
-
-        - pass `symprec` to skip the sweep and fit at exactly that tolerance
-          ("set it if you are sure what it should be");
-        - pass `target_spacegroup` to pick the tightest tolerance in the sweep
-          that yields that space group;
-        - pass `symprec_range` to sweep a fixed list of tolerances instead of
-          scanning automatically.
+        Nothing is scanned, so this costs a single symmetry fit — use it when
+        you already know the tolerance you want.
 
         Parameters
         ----------
-        symprec : float | None
-            If given, fit at exactly this tolerance (Ångstrom) and skip the
-            sweep. `result.symprec` equals this value. Raises `ValueError` if
-            the symmetry search fails at this tolerance.
-            Mutually exclusive with `target_spacegroup` and with every setting
-            that configures the sweep.
-        target_spacegroup : int | str | None
-            If given, select the tightest (smallest) symprec in the sweep whose
-            fit matches this space group. An `int` is matched against the
-            international number, a `str` against the Hermann-Mauguin symbol
-            (case-insensitive, whitespace-insensitive). Raises `ValueError`
-            listing what was found at each symprec if nothing matches. Mutually
-            exclusive with `symprec`.
-        symprec_range : tuple[float, ...] | None
-            If given, sweep exactly these tolerances (Ångstrom) instead of
-            scanning `symprec_min`..`symprec_max` automatically. The tolerance
-            giving the highest space group number wins either way; ties are
-            broken towards the tightest (smallest) tolerance. Mutually
-            exclusive with the scan settings below.
-        symprec_min : float | None
-            Tightest tolerance (Ångstrom) of the automatic scan, default
-            0.01 Å.
-        symprec_max : float | None
-            Loosest tolerance (Ångstrom) of the automatic scan, default 0.5 Å.
-        n_samples : int | None
-            Number of log-spaced tolerances in the automatic scan, default
-            40.
+        symprec : float
+            Symmetry tolerance (Ångstrom) to fit at.
         angle_tolerance : float
             Angle tolerance (degrees) passed to
             [pymatgen.symmetry.analyzer.SpacegroupAnalyzer][].
@@ -451,116 +710,56 @@ class Crystallizer:
         Returns
         -------
         result : CrystallizerResult
-            The symmetrized structure and the fitted space group. When a sweep
-            was run, `result.ranking` holds the full symmetry ranking (ordered
-            by required deviation ascending) and `result.candidates` the
-            distinct space groups found, ranked by number descending.
+            The symmetrized structure and the fitted space group.
 
         Raises
         ------
         ValueError
-            If `symprec` is combined with any argument that configures the
-            sweep; if the fit fails at an explicit `symprec`; if no
-            `target_spacegroup` match is found; or if no symprec in the sweep
-            yields a symmetry.
+            If the symmetry search fails at this tolerance.
         """
-        if symprec is not None:
-            conflicting = [
-                name
-                for name, value in (
-                    ('target_spacegroup', target_spacegroup),
-                    ('symprec_range', symprec_range),
-                    ('symprec_min', symprec_min),
-                    ('symprec_max', symprec_max),
-                    ('n_samples', n_samples),
-                )
-                if value is not None
-            ]
-            if conflicting:
-                listed = ', '.join(f'`{name}`' for name in conflicting)
-                raise ValueError(
-                    f'`symprec` pins the tolerance, so it cannot be combined with '
-                    f'{listed}; those select a tolerance from a sweep.'
-                )
-
         geometry, occupancies = self._geometry_and_occupancies(
             background_level=background_level, **find_peaks_kwargs
         )
+        return _fit(geometry, occupancies, symprec=symprec, angle_tolerance=angle_tolerance)
 
+    def _geometry_and_analyzer(
+        self,
+        *,
+        angle_tolerance: float,
+        background_level: float,
+        **find_peaks_kwargs,
+    ) -> tuple[Structure, np.ndarray, SymmetryAnalyzer]:
+        """Reconstruct the geometry and wrap it in a
+        [SymmetryAnalyzer][gemdat.symmetry.SymmetryAnalyzer]."""
+        geometry, occupancies = self._geometry_and_occupancies(
+            background_level=background_level, **find_peaks_kwargs
+        )
         analyzer = SymmetryAnalyzer(geometry, angle_tolerance=angle_tolerance)
-        ranking: SymmetryRanking | None = None
-
-        if symprec is not None:
-            best_symprec = symprec
-        else:
-            ranking = analyzer.rank(
-                symprec_range=symprec_range,
-                symprec_min=symprec_min,
-                symprec_max=symprec_max,
-                n_samples=n_samples,
-            )
-
-            if target_spacegroup is not None:
-                match = ranking.match(target_spacegroup)
-                if match is None:
-                    raise ValueError(
-                        f'No symprec in the sweep produced space group '
-                        f'{target_spacegroup!r}. Found:\n' + ranking.format()
-                    )
-                best_symprec = match.symprec
-            else:
-                # Raises if no tolerance in the sweep yielded a symmetry.
-                best_symprec = ranking.best().symprec
-
-        # The sweep already knows this tolerance works; an explicit `symprec`
-        # is only checked here, so that it is fitted exactly once either way.
-        try:
-            sga = SpacegroupAnalyzer(
-                geometry, symprec=best_symprec, angle_tolerance=angle_tolerance
-            )
-            symmetrized = sga.get_symmetrized_structure()
-            spacegroup_symbol = sga.get_space_group_symbol()
-            spacegroup_number = sga.get_space_group_number()
-        except Exception as exc:
-            raise ValueError(
-                f'Could not determine symmetry at symprec={best_symprec}: {exc}'
-            ) from exc
-
-        # Average occupancy within each symmetry-equivalent class so that
-        # equivalent sites are truly equivalent before the cif is written.
-        # `equivalent_indices` indexes into `geometry`'s site order, which is
-        # how `occupancies` is aligned.
-        new_species: list[dict] = [{} for _ in range(len(symmetrized))]
-        for group in symmetrized.equivalent_indices:
-            symbol = symmetrized[group[0]].specie.symbol
-            avg_occupancy = float(np.mean([occupancies[i] for i in group]))
-            for i in group:
-                new_species[i] = {symbol: avg_occupancy}
-
-        structure = Structure(
-            lattice=symmetrized.lattice,
-            species=new_species,
-            coords=[site.frac_coords for site in symmetrized],
-        )
-
-        return CrystallizerResult(
-            structure=structure,
-            spacegroup_symbol=spacegroup_symbol,
-            spacegroup_number=spacegroup_number,
-            symprec=best_symprec,
-            ranking=ranking,
-        )
+        return geometry, occupancies, analyzer
 
     def to_cif(self, filename: Path | str, **kwargs) -> CrystallizerResult:
         """Crystallize and write the result to a cif file (with symmetry).
+
+        This is [crystallize][gemdat.crystallizer.Crystallizer.crystallize]
+        followed by
+        [CrystallizerResult.to_cif][gemdat.crystallizer.CrystallizerResult.to_cif].
+        To write a fit chosen some other way, take it off a
+        [scan][gemdat.crystallizer.Crystallizer.scan] and let it write itself,
+        e.g. one file per space group found:
+
+        ```python
+        scan = crystallizer.scan()
+        for level in scan.candidates:
+            scan.at_level(level).to_cif(f'{level.spacegroup_number}.cif')
+        ```
 
         Parameters
         ----------
         filename : Path | str
             Output filename (a `.cif` suffix is enforced).
         **kwargs : dict
-            Passed through to [Crystallizer.crystallize][gemdat.crystallizer.Crys
-            tallizer.crystallize].
+            Passed through to
+            [crystallize][gemdat.crystallizer.Crystallizer.crystallize].
 
         Returns
         -------
@@ -568,5 +767,5 @@ class Crystallizer:
             The same result that was written to file.
         """
         result = self.crystallize(**kwargs)
-        write_cif(result.structure, filename, symprec=result.symprec)
+        result.to_cif(filename)
         return result

--- a/src/gemdat/symmetry.py
+++ b/src/gemdat/symmetry.py
@@ -1,0 +1,484 @@
+"""This module contains the symmetry analysis used by the
+[Crystallizer][gemdat.crystallizer.Crystallizer]: fitting the space group of a
+structure as a function of the symmetry tolerance
+([SymmetryAnalyzer][gemdat.symmetry.SymmetryAnalyzer]), and ranking the groups
+that turn up by how much tolerance each one actually needs
+([SymmetryRanking][gemdat.symmetry.SymmetryRanking])."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import TYPE_CHECKING, Iterator
+
+import numpy as np
+from pymatgen.core import Lattice
+from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
+
+if TYPE_CHECKING:
+    from pymatgen.core import Structure
+
+
+@dataclass
+class SymmetryLevel:
+    """One entry in a [SymmetryRanking][gemdat.symmetry.SymmetryRanking]: the
+    space group found at a single symmetry tolerance.
+
+    Parameters
+    ----------
+    symprec : float
+        Symmetry tolerance (in Ångstrom) at which this level was evaluated.
+    spacegroup_number : int | None
+        International number of the space group, or `None` if the symmetry
+        search failed at this tolerance.
+    spacegroup_symbol : str | None
+        International (Hermann-Mauguin) symbol, or `None` on failure.
+    crystal_system : str | None
+        Crystal system (e.g. `'cubic'`), or `None` on failure.
+    n_symmetry_ops : int | None
+        Number of symmetry operations in the space group, or `None` on failure.
+    n_site_orbits : int | None
+        Number of symmetry-distinct site groups (orbits), or `None` on failure.
+    deviation : float | None
+        How far the structure actually is from this symmetry: the largest
+        distance (Ångstrom) an atom must move for the group's operations to
+        hold exactly. This is a property of the structure, not of the search,
+        so it does not depend on the `symprec` that found the group. `None`
+        if it was not computed or could not be determined.
+    angle_deviation : float | None
+        The largest difference (degrees) between the input cell angles and
+        those of the idealised cell for this group, i.e. the smallest
+        `angle_tolerance` the fit needs. `None` if not computed.
+    n_observed : int | None
+        Only set by [scan][gemdat.symmetry.SymmetryAnalyzer.scan]: how many of
+        the scanned tolerances yielded this space group, as a measure of how
+        robustly it holds. `None` when the tolerances were given explicitly.
+    error : str | None
+        The exception message if the symmetry search raised, else `None`.
+    """
+
+    symprec: float
+    spacegroup_number: int | None = None
+    spacegroup_symbol: str | None = None
+    crystal_system: str | None = None
+    n_symmetry_ops: int | None = None
+    n_site_orbits: int | None = None
+    deviation: float | None = None
+    angle_deviation: float | None = None
+    n_observed: int | None = None
+    error: str | None = None
+
+
+def _normalize_spacegroup_symbol(symbol: str) -> str:
+    """Strip all whitespace and lower-case a Hermann-Mauguin symbol for
+    tolerant matching."""
+    return ''.join(symbol.split()).lower()
+
+
+class SymmetryRanking:
+    """The space groups a structure was found to adopt, in the order they were
+    evaluated.
+
+    Wraps a list of [SymmetryLevel][gemdat.symmetry.SymmetryLevel]s and behaves
+    like one (iteration, indexing, `len`), adding the queries that make it a
+    ranking: which groups turn up ([candidates][
+    gemdat.symmetry.SymmetryRanking.candidates]), which one wins
+    ([best][gemdat.symmetry.SymmetryRanking.best]), and whether a given group
+    is reachable at all ([match][gemdat.symmetry.SymmetryRanking.match]).
+    """
+
+    def __init__(self, levels: list[SymmetryLevel]):
+        """Set up the ranking.
+
+        Parameters
+        ----------
+        levels : list[SymmetryLevel]
+            Evaluated levels, in the order they should be reported.
+        """
+        self.levels = list(levels)
+
+    def __len__(self) -> int:
+        return len(self.levels)
+
+    def __iter__(self) -> Iterator[SymmetryLevel]:
+        return iter(self.levels)
+
+    def __getitem__(self, index):
+        return self.levels[index]
+
+    def __repr__(self) -> str:
+        groups = ', '.join(
+            f'{level.spacegroup_symbol} ({level.spacegroup_number})' for level in self.found
+        )
+        return f'{type(self).__name__}({groups})'
+
+    @property
+    def found(self) -> list[SymmetryLevel]:
+        """The levels at which a space group was actually determined.
+
+        Returns
+        -------
+        list[SymmetryLevel]
+            Levels whose symmetry search succeeded, in ranking order.
+        """
+        return [level for level in self.levels if level.spacegroup_number is not None]
+
+    @property
+    def candidates(self) -> list[SymmetryLevel]:
+        """The distinct space groups found ("Top-X").
+
+        Returns
+        -------
+        list[SymmetryLevel]
+            One level per space group, each the one that needed the tightest
+            `symprec`, ranked by space-group number descending.
+        """
+        tightest: dict[int, SymmetryLevel] = {}
+        for level in self.found:
+            assert level.spacegroup_number is not None
+            current = tightest.get(level.spacegroup_number)
+            if current is None or level.symprec < current.symprec:
+                tightest[level.spacegroup_number] = level
+        return sorted(
+            tightest.values(),
+            key=lambda level: level.spacegroup_number or 0,
+            reverse=True,
+        )
+
+    def match(self, target: int | str) -> SymmetryLevel | None:
+        """Return the level matching `target`, at the tightest tolerance that
+        reaches it.
+
+        Parameters
+        ----------
+        target : int | str
+            International number, or Hermann-Mauguin symbol (matched
+            case-insensitively and ignoring whitespace).
+
+        Returns
+        -------
+        SymmetryLevel | None
+            The matching level, or `None` if the target was never reached.
+        """
+        if isinstance(target, str):
+            wanted = _normalize_spacegroup_symbol(target)
+            matches = [
+                level
+                for level in self.found
+                if level.spacegroup_symbol is not None
+                and _normalize_spacegroup_symbol(level.spacegroup_symbol) == wanted
+            ]
+        else:
+            matches = [level for level in self.found if level.spacegroup_number == target]
+
+        if not matches:
+            return None
+        return min(matches, key=lambda level: level.symprec)
+
+    def best(self) -> SymmetryLevel:
+        """Return the winning level: the highest space-group number, ties
+        broken towards the tightest tolerance.
+
+        Returns
+        -------
+        SymmetryLevel
+
+        Raises
+        ------
+        ValueError
+            If no level in the ranking yielded a space group.
+        """
+        if not self.found:
+            raise ValueError(
+                'Could not determine symmetry for any of the swept symprec values.'
+            )
+        return max(
+            self.found,
+            key=lambda level: (level.spacegroup_number or 0, -level.symprec),
+        )
+
+    def format(self) -> str:
+        """Render the ranking as a readable fixed-width table.
+
+        Returns
+        -------
+        str
+            One row per level, with columns `symprec (Å)`, `deviation (Å)`,
+            `angle dev (°)`, `space group`, `#`, `crystal system`, `# orbits`
+            and `# hits`. A tolerance at which the symmetry search failed shows
+            `failed`/`-`, as does any column that was not computed.
+        """
+        headers = (
+            'symprec (Å)',
+            'deviation (Å)',
+            'angle dev (°)',
+            'space group',
+            '#',
+            'crystal system',
+            '# orbits',
+            '# hits',
+        )
+        rows: list[tuple[str, ...]] = []
+        for level in self.levels:
+            hits = str(level.n_observed) if level.n_observed is not None else '-'
+            deviation = f'{level.deviation:.4g}' if level.deviation is not None else '-'
+            angle = f'{level.angle_deviation:.3g}' if level.angle_deviation is not None else '-'
+            if level.spacegroup_number is None:
+                rows.append(
+                    (f'{level.symprec:g}', deviation, angle, 'failed', '-', '-', '-', hits)
+                )
+            else:
+                orbits = str(level.n_site_orbits) if level.n_site_orbits is not None else '-'
+                rows.append(
+                    (
+                        f'{level.symprec:g}',
+                        deviation,
+                        angle,
+                        level.spacegroup_symbol or '-',
+                        str(level.spacegroup_number),
+                        level.crystal_system or '-',
+                        orbits,
+                        hits,
+                    )
+                )
+
+        widths = [
+            max([len(headers[i])] + [len(row[i]) for row in rows]) for i in range(len(headers))
+        ]
+
+        def _fmt(cells: tuple[str, ...]) -> str:
+            return '  '.join(cell.ljust(width) for cell, width in zip(cells, widths))
+
+        lines = [_fmt(headers), _fmt(tuple('-' * width for width in widths))]
+        lines += [_fmt(row) for row in rows]
+        return '\n'.join(lines)
+
+
+class SymmetryAnalyzer:
+    """Fit the space group of a structure as a function of the symmetry
+    tolerance.
+
+    [pymatgen.symmetry.analyzer.SpacegroupAnalyzer][] can only be asked
+    "which space group at this tolerance?" — never the inverse, and a
+    single very loose tolerance is no shortcut, since it returns one
+    group or fails outright. This class therefore samples tolerances to
+    find out *which* groups a structure can adopt, and then measures
+    *how much* each one costs (see
+    [level][gemdat.symmetry.SymmetryAnalyzer.level]) instead of
+    searching for it.
+    """
+
+    def __init__(self, structure: Structure, *, angle_tolerance: float = 5.0):
+        """Set up the analyzer.
+
+        Parameters
+        ----------
+        structure : Structure
+            Structure to fit. It must be geometry-only (all sites at full
+            occupancy): partial occupancies make every site distinct to the
+            symmetry finder and collapse the result to P1.
+        angle_tolerance : float
+            Angle tolerance (degrees) passed to
+            [pymatgen.symmetry.analyzer.SpacegroupAnalyzer][].
+        """
+        self.structure = structure
+        self.angle_tolerance = angle_tolerance
+
+    def _deviation(self, sga: SpacegroupAnalyzer) -> tuple[float | None, float | None]:
+        """Measure how far the structure really is from the symmetry `sga`
+        found.
+
+        The symmetry finder only reports *whether* a group holds within the
+        given tolerances, never how much slack it needed. That slack is
+        recoverable from the symmetry dataset, which gives the operations in
+        the input cell's own frame plus the idealised standard cell:
+
+        - applying each operation and measuring the distance to the nearest
+          site of the same species gives the largest displacement the group
+          demands;
+        - transforming the idealised standard lattice back into the input
+          basis and comparing cell angles gives the angular slack.
+
+        Both are properties of the structure rather than of the search, so
+        they do not depend on the `symprec` at which the group was found.
+
+        Returns
+        -------
+        tuple[float | None, float | None]
+            Maximum displacement (Ångstrom) and maximum angle difference
+            (degrees), or `(None, None)` if they could not be determined.
+        """
+        structure = self.structure
+        try:
+            dataset = sga.get_symmetry_dataset()
+            if dataset is None:
+                return None, None
+
+            frac_coords = structure.frac_coords
+            symbols = np.array([site.specie.symbol for site in structure])
+            # An operation may only map a site onto a site of the same species.
+            forbidden = symbols[:, None] != symbols[None, :]
+
+            # One operation at a time: the distances are measured with the
+            # lattice metric under periodic boundaries, and batching
+            # operations only makes the intermediates bigger without going
+            # faster. Cost grows as operations x sites^2, which is why this is
+            # not done for every tolerance in a scan.
+            deviation = 0.0
+            for rotation, translation in zip(dataset.rotations, dataset.translations):
+                mapped = frac_coords @ np.asarray(rotation).T + np.asarray(translation)
+                distances = structure.lattice.get_all_distances(mapped, frac_coords)
+                distances[forbidden] = np.inf
+                deviation = max(deviation, float(distances.min(axis=1).max()))
+
+            # (a_s b_s c_s) = (a b c) P^-1, up to the rigid rotation R that
+            # spglib applies to the standard cell, so undo R and re-apply P.
+            unrotated = dataset.std_lattice @ np.linalg.inv(dataset.std_rotation_matrix).T
+            idealized = Lattice((unrotated.T @ dataset.transformation_matrix).T)
+            angle_deviation = float(
+                np.abs(np.array(structure.lattice.angles) - np.array(idealized.angles)).max()
+            )
+        except Exception:  # noqa: BLE001 - the deviation is a diagnostic, not the fit
+            return None, None
+
+        return deviation, angle_deviation
+
+    def level(self, symprec: float, *, with_deviation: bool = False) -> SymmetryLevel:
+        """Fit the space group at a single tolerance.
+
+        Any exception raised by
+        [pymatgen.symmetry.analyzer.SpacegroupAnalyzer][] is caught and stored
+        on the returned level rather than propagated, so a sweep can continue
+        past a tolerance that fails.
+
+        Parameters
+        ----------
+        symprec : float
+            Symmetry tolerance (Ångstrom).
+        with_deviation : bool
+            Also measure the tolerances the fit actually needs. This loops
+            over the symmetry operations, so it is off by default.
+
+        Returns
+        -------
+        SymmetryLevel
+        """
+        try:
+            sga = SpacegroupAnalyzer(
+                self.structure, symprec=symprec, angle_tolerance=self.angle_tolerance
+            )
+            symmetrized = sga.get_symmetrized_structure()
+            deviation, angle_deviation = (
+                self._deviation(sga) if with_deviation else (None, None)
+            )
+            return SymmetryLevel(
+                symprec=symprec,
+                spacegroup_number=sga.get_space_group_number(),
+                spacegroup_symbol=sga.get_space_group_symbol(),
+                crystal_system=sga.get_crystal_system(),
+                n_symmetry_ops=len(sga.get_symmetry_operations()),
+                n_site_orbits=len(symmetrized.equivalent_indices),
+                deviation=deviation,
+                angle_deviation=angle_deviation,
+            )
+        except Exception as exc:  # noqa: BLE001 - record, don't drop, the failure
+            return SymmetryLevel(symprec=symprec, error=str(exc))
+
+    def levels(self, symprec_range: tuple[float, ...]) -> SymmetryRanking:
+        """Fit the space group at each of a fixed list of tolerances.
+
+        Parameters
+        ----------
+        symprec_range : tuple[float, ...]
+            Symmetry tolerances (Ångstrom) to evaluate.
+
+        Returns
+        -------
+        SymmetryRanking
+            One level per tolerance, ordered by symprec ascending. Deviations
+            are not measured; use [scan][gemdat.symmetry.SymmetryAnalyzer.scan]
+            for those.
+        """
+        return SymmetryRanking([self.level(symprec) for symprec in sorted(symprec_range)])
+
+    def scan(
+        self,
+        *,
+        symprec_min: float = 0.01,
+        symprec_max: float = 0.5,
+        n_samples: int = 40,
+    ) -> SymmetryRanking:
+        """Find every space group the structure adopts between `symprec_min`
+        and `symprec_max`, and how far the structure is from each one.
+
+        The candidate groups are enumerated by sampling a log-spaced grid of
+        tolerances over the whole range. The tolerance each group *requires*
+        is then measured directly rather than searched for: `deviation` and
+        `angle_deviation` record how far the structure actually sits from that
+        symmetry. Those are properties of the structure, so unlike the
+        `symprec` at which a group happens to turn up they are exact and
+        independent of the sampling.
+
+        The group is *not* a monotone function of `symprec`: a structure can
+        flicker between two groups over a range of tolerances before settling
+        on the higher-symmetry one. `n_observed` counts how many of the
+        `n_samples` grid points gave each group, which distinguishes a group
+        that holds over a wide range from one seen in a single narrow window.
+
+        Parameters
+        ----------
+        symprec_min : float
+            Tightest tolerance (Ångstrom) to scan.
+        symprec_max : float
+            Loosest tolerance (Ångstrom) to scan. Beyond ~0.5 Å the fit says
+            more about the tolerance than about the structure.
+        n_samples : int
+            Number of log-spaced tolerances in the scan. A group occupying a
+            window narrower than the grid spacing can be missed.
+
+        Returns
+        -------
+        SymmetryRanking
+            One level per distinct space group found, ordered by `deviation`
+            ascending, each carrying the tightest sampled `symprec` that
+            produced it. Empty if no tolerance in the range yielded a
+            symmetry.
+
+        Raises
+        ------
+        ValueError
+            If the scan range or sample count is not usable.
+        """
+        if symprec_min <= 0:
+            raise ValueError('`symprec_min` must be positive.')
+        if symprec_max < symprec_min:
+            raise ValueError('`symprec_max` must not be smaller than `symprec_min`.')
+        if n_samples < 2:
+            raise ValueError('`n_samples` must be at least 2.')
+
+        samples = [
+            float(symprec) for symprec in np.geomspace(symprec_min, symprec_max, n_samples)
+        ]
+        levels = [self.level(symprec) for symprec in samples]
+
+        counts: dict[int, int] = {}
+        first_seen: dict[int, int] = {}
+        for index, level in enumerate(levels):
+            number = level.spacegroup_number
+            if number is None:
+                continue
+            counts[number] = counts.get(number, 0) + 1
+            first_seen.setdefault(number, index)
+
+        # Re-fit each distinct group once at the tightest symprec that
+        # produced it, this time measuring the tolerances it actually needs.
+        thresholds = [
+            replace(
+                self.level(samples[index], with_deviation=True),
+                n_observed=counts[number],
+            )
+            for number, index in first_seen.items()
+        ]
+
+        return SymmetryRanking(
+            sorted(thresholds, key=lambda level: (level.deviation is None, level.deviation))
+        )

--- a/src/gemdat/symmetry.py
+++ b/src/gemdat/symmetry.py
@@ -7,8 +7,9 @@ that turn up by how much tolerance each one actually needs
 
 from __future__ import annotations
 
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, replace
-from typing import TYPE_CHECKING, Any, Iterator, overload
+from typing import TYPE_CHECKING, Any, overload
 
 import numpy as np
 from pymatgen.core import Lattice
@@ -17,10 +18,6 @@ from scipy.optimize import linear_sum_assignment
 
 if TYPE_CHECKING:
     from pymatgen.core import Structure
-
-DEFAULT_SYMPREC_MIN = 0.01
-DEFAULT_SYMPREC_MAX = 0.5
-DEFAULT_N_SAMPLES = 40
 
 
 @dataclass
@@ -54,9 +51,10 @@ class SymmetryLevel:
         those of the idealised cell for this group, i.e. the smallest
         `angle_tolerance` the fit needs. `None` if not computed.
     n_observed : int | None
-        Only set by [scan][gemdat.symmetry.SymmetryAnalyzer.scan]: how many of
-        the scanned tolerances yielded this space group, as a measure of how
-        robustly it holds. `None` when the tolerances were given explicitly.
+        Only set by a scan (see
+        [rank][gemdat.symmetry.SymmetryAnalyzer.rank]): how many of the scanned
+        tolerances yielded this space group, as a measure of how robustly it
+        holds. `None` when the tolerances were given explicitly.
     error : str | None
         The exception message if the symmetry search raised, or if the
         deviation could not be measured (in which case the space group was
@@ -94,33 +92,32 @@ def _rank_key(level: SymmetryLevel) -> tuple[bool, float, float]:
     )
 
 
-class SymmetryRanking:
+class SymmetryRanking(Sequence[SymmetryLevel]):
     """The space groups a structure was found to adopt, in the order they were
     evaluated.
 
-    Wraps a list of [SymmetryLevel][gemdat.symmetry.SymmetryLevel]s and behaves
-    like one (iteration, indexing, `len`), adding the queries that make it a
-    ranking: which groups turn up ([candidates][
+    A read-only sequence of
+    [SymmetryLevel][gemdat.symmetry.SymmetryLevel]s (iteration,
+    indexing, `len`), plus the queries that make it a ranking: which
+    groups turn up ([candidates][
     gemdat.symmetry.SymmetryRanking.candidates]), which one wins
-    ([best][gemdat.symmetry.SymmetryRanking.best]), and whether a given group
-    is reachable at all ([match][gemdat.symmetry.SymmetryRanking.match]).
+    ([best][gemdat.symmetry.SymmetryRanking.best]), and whether a given
+    group is reachable at all
+    ([match][gemdat.symmetry.SymmetryRanking.match]).
     """
 
-    def __init__(self, levels: list[SymmetryLevel]):
+    def __init__(self, levels: Iterable[SymmetryLevel]):
         """Set up the ranking.
 
         Parameters
         ----------
-        levels : list[SymmetryLevel]
+        levels : Iterable[SymmetryLevel]
             Evaluated levels, in the order they should be reported.
         """
-        self.levels = list(levels)
+        self._levels = list(levels)
 
     def __len__(self) -> int:
-        return len(self.levels)
-
-    def __iter__(self) -> Iterator[SymmetryLevel]:
-        return iter(self.levels)
+        return len(self._levels)
 
     @overload
     def __getitem__(self, index: int) -> SymmetryLevel: ...
@@ -129,7 +126,7 @@ class SymmetryRanking:
     def __getitem__(self, index: slice) -> list[SymmetryLevel]: ...
 
     def __getitem__(self, index: int | slice) -> SymmetryLevel | list[SymmetryLevel]:
-        return self.levels[index]
+        return self._levels[index]
 
     def __repr__(self) -> str:
         groups = ', '.join(
@@ -146,7 +143,7 @@ class SymmetryRanking:
         list[SymmetryLevel]
             Levels whose symmetry search succeeded, in ranking order.
         """
-        return [level for level in self.levels if level.spacegroup_number is not None]
+        return [level for level in self if level.spacegroup_number is not None]
 
     @property
     def candidates(self) -> list[SymmetryLevel]:
@@ -262,7 +259,7 @@ class SymmetryRanking:
                 cell(level.n_site_orbits),
                 cell(level.n_observed),
             )
-            for level in self.levels
+            for level in self
         ]
 
         widths = [
@@ -284,11 +281,10 @@ class SymmetryAnalyzer:
     [pymatgen.symmetry.analyzer.SpacegroupAnalyzer][] can only be asked
     "which space group at this tolerance?" — never the inverse, and a
     single very loose tolerance is no shortcut, since it returns one
-    group or fails outright. This class therefore samples tolerances to
-    find out *which* groups a structure can adopt, and then measures
-    *how much* each one costs (see
-    [level][gemdat.symmetry.SymmetryAnalyzer.level]) instead of
-    searching for it.
+    group or fails outright.
+    [rank][gemdat.symmetry.SymmetryAnalyzer.rank] therefore samples
+    tolerances to find out *which* groups a structure can adopt, and
+    then measures *how much* each one costs instead of searching for it.
     """
 
     def __init__(self, structure: Structure, *, angle_tolerance: float = 5.0):
@@ -376,7 +372,7 @@ class SymmetryAnalyzer:
 
         return deviation, angle_deviation, None
 
-    def level(self, symprec: float, *, with_deviation: bool = False) -> SymmetryLevel:
+    def _level(self, symprec: float, *, with_deviation: bool = False) -> SymmetryLevel:
         """Fit the space group at a single tolerance.
 
         Any exception raised by
@@ -424,104 +420,6 @@ class SymmetryAnalyzer:
         except Exception as exc:  # noqa: BLE001 - record, don't drop, the failure
             return SymmetryLevel(symprec=symprec, error=str(exc))
 
-    def levels(self, symprec_range: tuple[float, ...]) -> SymmetryRanking:
-        """Fit the space group at each of a fixed list of tolerances.
-
-        Parameters
-        ----------
-        symprec_range : tuple[float, ...]
-            Symmetry tolerances (Ångstrom) to evaluate.
-
-        Returns
-        -------
-        SymmetryRanking
-            One level per tolerance, ordered by symprec ascending. Deviations
-            are not measured; use [scan][gemdat.symmetry.SymmetryAnalyzer.scan]
-            for those.
-        """
-        return SymmetryRanking([self.level(symprec) for symprec in sorted(symprec_range)])
-
-    def scan(
-        self,
-        *,
-        symprec_min: float = DEFAULT_SYMPREC_MIN,
-        symprec_max: float = DEFAULT_SYMPREC_MAX,
-        n_samples: int = DEFAULT_N_SAMPLES,
-    ) -> SymmetryRanking:
-        """Find every space group the structure adopts between `symprec_min`
-        and `symprec_max`, and how far the structure is from each one.
-
-        The candidate groups are enumerated by sampling a log-spaced grid of
-        tolerances over the whole range. The tolerance each group *requires*
-        is then measured directly rather than searched for: `deviation` and
-        `angle_deviation` record how far the structure actually sits from that
-        symmetry. Those are properties of the structure, so unlike the
-        `symprec` at which a group happens to turn up they are exact and
-        independent of the sampling.
-
-        The group is *not* a monotone function of `symprec`: a structure can
-        flicker between two groups over a range of tolerances before settling
-        on the higher-symmetry one. `n_observed` counts how many of the
-        `n_samples` grid points gave each group, which distinguishes a group
-        that holds over a wide range from one seen in a single narrow window.
-
-        Parameters
-        ----------
-        symprec_min : float
-            Tightest tolerance (Ångstrom) to scan.
-        symprec_max : float
-            Loosest tolerance (Ångstrom) to scan. Beyond ~0.5 Å the fit says
-            more about the tolerance than about the structure.
-        n_samples : int
-            Number of log-spaced tolerances in the scan. A group occupying a
-            window narrower than the grid spacing can be missed.
-
-        Returns
-        -------
-        SymmetryRanking
-            One level per distinct space group found, ordered by `deviation`
-            ascending (ties broken on `angle_deviation`), each carrying the
-            tightest sampled `symprec` that produced it. Empty if no tolerance
-            in the range yielded a symmetry.
-
-        Raises
-        ------
-        ValueError
-            If the scan range or sample count is not usable.
-        """
-        if symprec_min <= 0:
-            raise ValueError('`symprec_min` must be positive.')
-        if symprec_max < symprec_min:
-            raise ValueError('`symprec_max` must not be smaller than `symprec_min`.')
-        if n_samples < 2:
-            raise ValueError('`n_samples` must be at least 2.')
-
-        samples = [
-            float(symprec) for symprec in np.geomspace(symprec_min, symprec_max, n_samples)
-        ]
-        levels = [self.level(symprec) for symprec in samples]
-
-        counts: dict[int, int] = {}
-        first_seen: dict[int, int] = {}
-        for index, level in enumerate(levels):
-            number = level.spacegroup_number
-            if number is None:
-                continue
-            counts[number] = counts.get(number, 0) + 1
-            first_seen.setdefault(number, index)
-
-        # Re-fit each distinct group once at the tightest symprec that
-        # produced it, this time measuring the tolerances it actually needs.
-        thresholds = [
-            replace(
-                self.level(samples[index], with_deviation=True),
-                n_observed=counts[number],
-            )
-            for number, index in first_seen.items()
-        ]
-
-        return SymmetryRanking(sorted(thresholds, key=_rank_key))
-
     def rank(
         self,
         *,
@@ -533,10 +431,23 @@ class SymmetryAnalyzer:
         """Rank the space groups the structure adopts, scanning the tolerance
         automatically unless a fixed list of tolerances is given.
 
-        This is the entry point callers should use: it dispatches to
-        [scan][gemdat.symmetry.SymmetryAnalyzer.scan] or to
-        [levels][gemdat.symmetry.SymmetryAnalyzer.levels] and rejects
-        combinations of arguments that would silently ignore one of them.
+        The scan enumerates the candidate groups by sampling a log-spaced grid
+        of tolerances between `symprec_min` and `symprec_max`. What each group
+        *costs* is then measured directly rather than searched for: `deviation`
+        and `angle_deviation` record how far the structure actually sits from
+        that symmetry. Those are properties of the structure, so unlike the
+        `symprec` at which a group happens to turn up they are exact and
+        independent of the sampling.
+
+        The group is *not* a monotone function of `symprec`: a structure can
+        flicker between two groups over a range of tolerances before settling
+        on the higher-symmetry one. `n_observed` counts how many of the
+        `n_samples` grid points gave each group, which distinguishes a group
+        that holds over a wide range from one seen in a single narrow window.
+
+        Passing `symprec_range` sweeps exactly those tolerances instead, one
+        level each. The deviations are not measured then, since measuring is
+        operations x sites^2 and a sweep repeats the same groups.
 
         Parameters
         ----------
@@ -544,18 +455,24 @@ class SymmetryAnalyzer:
             If given, evaluate exactly these tolerances (Ångstrom) instead of
             scanning. Mutually exclusive with the scan settings below.
         symprec_min : float | None
-            Tightest tolerance (Ångstrom) of the scan, default
-            `DEFAULT_SYMPREC_MIN`.
+            Tightest tolerance (Ångstrom) of the scan, default 0.01 Å.
         symprec_max : float | None
-            Loosest tolerance (Ångstrom) of the scan, default
-            `DEFAULT_SYMPREC_MAX`.
+            Loosest tolerance (Ångstrom) of the scan, default 0.5 Å. Beyond
+            ~0.5 Å the fit says more about the tolerance than about the
+            structure.
         n_samples : int | None
-            Number of log-spaced tolerances in the scan, default
-            `DEFAULT_N_SAMPLES`.
+            Number of log-spaced tolerances in the scan, default 40. A group
+            occupying a window narrower than the grid spacing can be missed.
 
         Returns
         -------
         SymmetryRanking
+            From the scan: one level per distinct space group found, ordered by
+            `deviation` ascending (ties broken on `angle_deviation`), each
+            carrying the tightest sampled `symprec` that produced it. Empty if
+            no tolerance in the range yielded a symmetry. From an explicit
+            `symprec_range`: one level per tolerance, ordered by symprec
+            ascending.
 
         Raises
         ------
@@ -579,10 +496,41 @@ class SymmetryAnalyzer:
                     f'`symprec_range` lists the tolerances explicitly, so it cannot be '
                     f'combined with {listed}; those only configure the automatic scan.'
                 )
-            return self.levels(symprec_range)
+            return SymmetryRanking([self._level(symprec) for symprec in sorted(symprec_range)])
 
-        return self.scan(
-            symprec_min=DEFAULT_SYMPREC_MIN if symprec_min is None else symprec_min,
-            symprec_max=DEFAULT_SYMPREC_MAX if symprec_max is None else symprec_max,
-            n_samples=DEFAULT_N_SAMPLES if n_samples is None else n_samples,
-        )
+        symprec_min = 0.01 if symprec_min is None else symprec_min
+        symprec_max = 0.5 if symprec_max is None else symprec_max
+        n_samples = 40 if n_samples is None else n_samples
+
+        if symprec_min <= 0:
+            raise ValueError('`symprec_min` must be positive.')
+        if symprec_max < symprec_min:
+            raise ValueError('`symprec_max` must not be smaller than `symprec_min`.')
+        if n_samples < 2:
+            raise ValueError('`n_samples` must be at least 2.')
+
+        samples = [
+            float(symprec) for symprec in np.geomspace(symprec_min, symprec_max, n_samples)
+        ]
+        levels = [self._level(symprec) for symprec in samples]
+
+        counts: dict[int, int] = {}
+        first_seen: dict[int, int] = {}
+        for index, level in enumerate(levels):
+            number = level.spacegroup_number
+            if number is None:
+                continue
+            counts[number] = counts.get(number, 0) + 1
+            first_seen.setdefault(number, index)
+
+        # Re-fit each distinct group once at the tightest symprec that
+        # produced it, this time measuring the tolerances it actually needs.
+        thresholds = [
+            replace(
+                self._level(samples[index], with_deviation=True),
+                n_observed=counts[number],
+            )
+            for number, index in first_seen.items()
+        ]
+
+        return SymmetryRanking(sorted(thresholds, key=_rank_key))

--- a/src/gemdat/symmetry.py
+++ b/src/gemdat/symmetry.py
@@ -8,14 +8,19 @@ that turn up by how much tolerance each one actually needs
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
-from typing import TYPE_CHECKING, Iterator
+from typing import TYPE_CHECKING, Any, Iterator, overload
 
 import numpy as np
 from pymatgen.core import Lattice
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
+from scipy.optimize import linear_sum_assignment
 
 if TYPE_CHECKING:
     from pymatgen.core import Structure
+
+DEFAULT_SYMPREC_MIN = 0.01
+DEFAULT_SYMPREC_MAX = 0.5
+DEFAULT_N_SAMPLES = 40
 
 
 @dataclass
@@ -53,7 +58,9 @@ class SymmetryLevel:
         the scanned tolerances yielded this space group, as a measure of how
         robustly it holds. `None` when the tolerances were given explicitly.
     error : str | None
-        The exception message if the symmetry search raised, else `None`.
+        The exception message if the symmetry search raised, or if the
+        deviation could not be measured (in which case the space group was
+        still determined), else `None`.
     """
 
     symprec: float
@@ -72,6 +79,19 @@ def _normalize_spacegroup_symbol(symbol: str) -> str:
     """Strip all whitespace and lower-case a Hermann-Mauguin symbol for
     tolerant matching."""
     return ''.join(symbol.split()).lower()
+
+
+def _rank_key(level: SymmetryLevel) -> tuple[bool, float, float]:
+    """Sort key ranking levels by how little the structure has to give up:
+    smallest positional deviation first, ties broken on the angular one.
+
+    Levels whose deviation could not be measured sort last.
+    """
+    return (
+        level.deviation is None,
+        level.deviation if level.deviation is not None else 0.0,
+        level.angle_deviation if level.angle_deviation is not None else 0.0,
+    )
 
 
 class SymmetryRanking:
@@ -102,7 +122,13 @@ class SymmetryRanking:
     def __iter__(self) -> Iterator[SymmetryLevel]:
         return iter(self.levels)
 
-    def __getitem__(self, index):
+    @overload
+    def __getitem__(self, index: int) -> SymmetryLevel: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> list[SymmetryLevel]: ...
+
+    def __getitem__(self, index: int | slice) -> SymmetryLevel | list[SymmetryLevel]:
         return self.levels[index]
 
     def __repr__(self) -> str:
@@ -134,15 +160,15 @@ class SymmetryRanking:
         """
         tightest: dict[int, SymmetryLevel] = {}
         for level in self.found:
-            assert level.spacegroup_number is not None
-            current = tightest.get(level.spacegroup_number)
+            number = level.spacegroup_number
+            assert number is not None  # `found` drops the failures
+            current = tightest.get(number)
             if current is None or level.symprec < current.symprec:
-                tightest[level.spacegroup_number] = level
-        return sorted(
-            tightest.values(),
-            key=lambda level: level.spacegroup_number or 0,
-            reverse=True,
-        )
+                tightest[number] = level
+        return [
+            level
+            for _, level in sorted(tightest.items(), key=lambda item: item[0], reverse=True)
+        ]
 
     def match(self, target: int | str) -> SymmetryLevel | None:
         """Return the level matching `target`, at the tightest tolerance that
@@ -203,9 +229,10 @@ class SymmetryRanking:
         -------
         str
             One row per level, with columns `symprec (Å)`, `deviation (Å)`,
-            `angle dev (°)`, `space group`, `#`, `crystal system`, `# orbits`
-            and `# hits`. A tolerance at which the symmetry search failed shows
-            `failed`/`-`, as does any column that was not computed.
+            `angle dev (°)`, `space group`, `#`, `crystal system`, `# ops`,
+            `# orbits` and `# hits`. A tolerance at which the symmetry search
+            failed shows `failed`/`-`, as does any column that was not
+            computed.
         """
         headers = (
             'symprec (Å)',
@@ -214,32 +241,29 @@ class SymmetryRanking:
             'space group',
             '#',
             'crystal system',
+            '# ops',
             '# orbits',
             '# hits',
         )
-        rows: list[tuple[str, ...]] = []
-        for level in self.levels:
-            hits = str(level.n_observed) if level.n_observed is not None else '-'
-            deviation = f'{level.deviation:.4g}' if level.deviation is not None else '-'
-            angle = f'{level.angle_deviation:.3g}' if level.angle_deviation is not None else '-'
-            if level.spacegroup_number is None:
-                rows.append(
-                    (f'{level.symprec:g}', deviation, angle, 'failed', '-', '-', '-', hits)
-                )
-            else:
-                orbits = str(level.n_site_orbits) if level.n_site_orbits is not None else '-'
-                rows.append(
-                    (
-                        f'{level.symprec:g}',
-                        deviation,
-                        angle,
-                        level.spacegroup_symbol or '-',
-                        str(level.spacegroup_number),
-                        level.crystal_system or '-',
-                        orbits,
-                        hits,
-                    )
-                )
+
+        def cell(value: object, spec: str = '') -> str:
+            """Render one value, or `-` if it was never determined."""
+            return '-' if value is None else format(value, spec)
+
+        rows: list[tuple[str, ...]] = [
+            (
+                f'{level.symprec:g}',
+                cell(level.deviation, '.4g'),
+                cell(level.angle_deviation, '.3g'),
+                cell(level.spacegroup_symbol) if level.spacegroup_number else 'failed',
+                cell(level.spacegroup_number),
+                cell(level.crystal_system),
+                cell(level.n_symmetry_ops),
+                cell(level.n_site_orbits),
+                cell(level.n_observed),
+            )
+            for level in self.levels
+        ]
 
         widths = [
             max([len(headers[i])] + [len(row[i]) for row in rows]) for i in range(len(headers))
@@ -283,17 +307,17 @@ class SymmetryAnalyzer:
         self.structure = structure
         self.angle_tolerance = angle_tolerance
 
-    def _deviation(self, sga: SpacegroupAnalyzer) -> tuple[float | None, float | None]:
-        """Measure how far the structure really is from the symmetry `sga`
-        found.
+    def _deviation(self, dataset: Any) -> tuple[float | None, float | None, str | None]:
+        """Measure how far the structure really is from the symmetry recorded
+        in `dataset`.
 
         The symmetry finder only reports *whether* a group holds within the
         given tolerances, never how much slack it needed. That slack is
         recoverable from the symmetry dataset, which gives the operations in
         the input cell's own frame plus the idealised standard cell:
 
-        - applying each operation and measuring the distance to the nearest
-          site of the same species gives the largest displacement the group
+        - applying each operation and matching its images one-to-one onto the
+          sites of the same species gives the largest displacement the group
           demands;
         - transforming the idealised standard lattice back into the input
           basis and comparing cell angles gives the angular slack.
@@ -301,18 +325,21 @@ class SymmetryAnalyzer:
         Both are properties of the structure rather than of the search, so
         they do not depend on the `symprec` at which the group was found.
 
+        Parameters
+        ----------
+        dataset : SpglibDataset
+            Symmetry dataset of the fit, from
+            [pymatgen.symmetry.analyzer.SpacegroupAnalyzer.get_symmetry_dataset][].
+
         Returns
         -------
-        tuple[float | None, float | None]
-            Maximum displacement (Ångstrom) and maximum angle difference
-            (degrees), or `(None, None)` if they could not be determined.
+        tuple[float | None, float | None, str | None]
+            Maximum displacement (Ångstrom), maximum angle difference
+            (degrees), and `None`; or `(None, None, message)` if they could not
+            be determined.
         """
         structure = self.structure
         try:
-            dataset = sga.get_symmetry_dataset()
-            if dataset is None:
-                return None, None
-
             frac_coords = structure.frac_coords
             symbols = np.array([site.specie.symbol for site in structure])
             # An operation may only map a site onto a site of the same species.
@@ -328,7 +355,12 @@ class SymmetryAnalyzer:
                 mapped = frac_coords @ np.asarray(rotation).T + np.asarray(translation)
                 distances = structure.lattice.get_all_distances(mapped, frac_coords)
                 distances[forbidden] = np.inf
-                deviation = max(deviation, float(distances.min(axis=1).max()))
+                # An operation permutes the sites, so the images must be
+                # matched one-to-one: taking each image's nearest site
+                # independently could send two images to the same site and
+                # understate the deviation.
+                rows, columns = linear_sum_assignment(distances)
+                deviation = max(deviation, float(distances[rows, columns].max(initial=0.0)))
 
             # (a_s b_s c_s) = (a b c) P^-1, up to the rigid rotation R that
             # spglib applies to the standard cell, so undo R and re-apply P.
@@ -337,10 +369,12 @@ class SymmetryAnalyzer:
             angle_deviation = float(
                 np.abs(np.array(structure.lattice.angles) - np.array(idealized.angles)).max()
             )
-        except Exception:  # noqa: BLE001 - the deviation is a diagnostic, not the fit
-            return None, None
+        except Exception as exc:  # noqa: BLE001 - a diagnostic, not the fit
+            # Reported on the level's `error` rather than dropped, so that a
+            # systematic failure does not just look like "not computed".
+            return None, None, f'Could not measure the deviation: {exc}'
 
-        return deviation, angle_deviation
+        return deviation, angle_deviation, None
 
     def level(self, symprec: float, *, with_deviation: bool = False) -> SymmetryLevel:
         """Fit the space group at a single tolerance.
@@ -366,19 +400,26 @@ class SymmetryAnalyzer:
             sga = SpacegroupAnalyzer(
                 self.structure, symprec=symprec, angle_tolerance=self.angle_tolerance
             )
-            symmetrized = sga.get_symmetrized_structure()
-            deviation, angle_deviation = (
-                self._deviation(sga) if with_deviation else (None, None)
+            dataset = sga.get_symmetry_dataset()
+            if dataset is None:
+                raise ValueError('spglib could not determine a symmetry dataset.')
+            deviation, angle_deviation, error = (
+                self._deviation(dataset) if with_deviation else (None, None, None)
             )
             return SymmetryLevel(
                 symprec=symprec,
                 spacegroup_number=sga.get_space_group_number(),
                 spacegroup_symbol=sga.get_space_group_symbol(),
                 crystal_system=sga.get_crystal_system(),
-                n_symmetry_ops=len(sga.get_symmetry_operations()),
-                n_site_orbits=len(symmetrized.equivalent_indices),
+                # Both counts come out of the dataset that is already in hand;
+                # `get_symmetry_operations()` and `get_symmetrized_structure()`
+                # would rebuild the same information for every sampled
+                # tolerance.
+                n_symmetry_ops=len(dataset.rotations),
+                n_site_orbits=len(set(dataset.equivalent_atoms)),
                 deviation=deviation,
                 angle_deviation=angle_deviation,
+                error=error,
             )
         except Exception as exc:  # noqa: BLE001 - record, don't drop, the failure
             return SymmetryLevel(symprec=symprec, error=str(exc))
@@ -403,9 +444,9 @@ class SymmetryAnalyzer:
     def scan(
         self,
         *,
-        symprec_min: float = 0.01,
-        symprec_max: float = 0.5,
-        n_samples: int = 40,
+        symprec_min: float = DEFAULT_SYMPREC_MIN,
+        symprec_max: float = DEFAULT_SYMPREC_MAX,
+        n_samples: int = DEFAULT_N_SAMPLES,
     ) -> SymmetryRanking:
         """Find every space group the structure adopts between `symprec_min`
         and `symprec_max`, and how far the structure is from each one.
@@ -439,9 +480,9 @@ class SymmetryAnalyzer:
         -------
         SymmetryRanking
             One level per distinct space group found, ordered by `deviation`
-            ascending, each carrying the tightest sampled `symprec` that
-            produced it. Empty if no tolerance in the range yielded a
-            symmetry.
+            ascending (ties broken on `angle_deviation`), each carrying the
+            tightest sampled `symprec` that produced it. Empty if no tolerance
+            in the range yielded a symmetry.
 
         Raises
         ------
@@ -479,6 +520,69 @@ class SymmetryAnalyzer:
             for number, index in first_seen.items()
         ]
 
-        return SymmetryRanking(
-            sorted(thresholds, key=lambda level: (level.deviation is None, level.deviation))
+        return SymmetryRanking(sorted(thresholds, key=_rank_key))
+
+    def rank(
+        self,
+        *,
+        symprec_range: tuple[float, ...] | None = None,
+        symprec_min: float | None = None,
+        symprec_max: float | None = None,
+        n_samples: int | None = None,
+    ) -> SymmetryRanking:
+        """Rank the space groups the structure adopts, scanning the tolerance
+        automatically unless a fixed list of tolerances is given.
+
+        This is the entry point callers should use: it dispatches to
+        [scan][gemdat.symmetry.SymmetryAnalyzer.scan] or to
+        [levels][gemdat.symmetry.SymmetryAnalyzer.levels] and rejects
+        combinations of arguments that would silently ignore one of them.
+
+        Parameters
+        ----------
+        symprec_range : tuple[float, ...] | None
+            If given, evaluate exactly these tolerances (Ångstrom) instead of
+            scanning. Mutually exclusive with the scan settings below.
+        symprec_min : float | None
+            Tightest tolerance (Ångstrom) of the scan, default
+            `DEFAULT_SYMPREC_MIN`.
+        symprec_max : float | None
+            Loosest tolerance (Ångstrom) of the scan, default
+            `DEFAULT_SYMPREC_MAX`.
+        n_samples : int | None
+            Number of log-spaced tolerances in the scan, default
+            `DEFAULT_N_SAMPLES`.
+
+        Returns
+        -------
+        SymmetryRanking
+
+        Raises
+        ------
+        ValueError
+            If `symprec_range` is combined with any of the scan settings, or if
+            the scan range or sample count is not usable.
+        """
+        if symprec_range is not None:
+            conflicting = [
+                name
+                for name, value in (
+                    ('symprec_min', symprec_min),
+                    ('symprec_max', symprec_max),
+                    ('n_samples', n_samples),
+                )
+                if value is not None
+            ]
+            if conflicting:
+                listed = ', '.join(f'`{name}`' for name in conflicting)
+                raise ValueError(
+                    f'`symprec_range` lists the tolerances explicitly, so it cannot be '
+                    f'combined with {listed}; those only configure the automatic scan.'
+                )
+            return self.levels(symprec_range)
+
+        return self.scan(
+            symprec_min=DEFAULT_SYMPREC_MIN if symprec_min is None else symprec_min,
+            symprec_max=DEFAULT_SYMPREC_MAX if symprec_max is None else symprec_max,
+            n_samples=DEFAULT_N_SAMPLES if n_samples is None else n_samples,
         )

--- a/src/gemdat/symmetry.py
+++ b/src/gemdat/symmetry.py
@@ -54,7 +54,8 @@ class SymmetryLevel:
         Only set by a scan (see
         [rank][gemdat.symmetry.SymmetryAnalyzer.rank]): how many of the scanned
         tolerances yielded this space group, as a measure of how robustly it
-        holds. `None` when the tolerances were given explicitly.
+        holds. `None` when the tolerances were given explicitly, i.e. from
+        [rank_at][gemdat.symmetry.SymmetryAnalyzer.rank_at].
     error : str | None
         The exception message if the symmetry search raised, or if the
         deviation could not be measured (in which case the space group was
@@ -285,6 +286,8 @@ class SymmetryAnalyzer:
     [rank][gemdat.symmetry.SymmetryAnalyzer.rank] therefore samples
     tolerances to find out *which* groups a structure can adopt, and
     then measures *how much* each one costs instead of searching for it.
+    [rank_at][gemdat.symmetry.SymmetryAnalyzer.rank_at] evaluates a fixed
+    list of tolerances instead, one level each.
     """
 
     def __init__(self, structure: Structure, *, angle_tolerance: float = 5.0):
@@ -423,13 +426,12 @@ class SymmetryAnalyzer:
     def rank(
         self,
         *,
-        symprec_range: tuple[float, ...] | None = None,
         symprec_min: float | None = None,
         symprec_max: float | None = None,
         n_samples: int | None = None,
     ) -> SymmetryRanking:
         """Rank the space groups the structure adopts, scanning the tolerance
-        automatically unless a fixed list of tolerances is given.
+        automatically.
 
         The scan enumerates the candidate groups by sampling a log-spaced grid
         of tolerances between `symprec_min` and `symprec_max`. What each group
@@ -445,15 +447,11 @@ class SymmetryAnalyzer:
         `n_samples` grid points gave each group, which distinguishes a group
         that holds over a wide range from one seen in a single narrow window.
 
-        Passing `symprec_range` sweeps exactly those tolerances instead, one
-        level each. The deviations are not measured then, since measuring is
-        operations x sites^2 and a sweep repeats the same groups.
+        To evaluate a fixed list of tolerances instead, use
+        [rank_at][gemdat.symmetry.SymmetryAnalyzer.rank_at].
 
         Parameters
         ----------
-        symprec_range : tuple[float, ...] | None
-            If given, evaluate exactly these tolerances (Ångstrom) instead of
-            scanning. Mutually exclusive with the scan settings below.
         symprec_min : float | None
             Tightest tolerance (Ångstrom) of the scan, default 0.01 Å.
         symprec_max : float | None
@@ -467,37 +465,16 @@ class SymmetryAnalyzer:
         Returns
         -------
         SymmetryRanking
-            From the scan: one level per distinct space group found, ordered by
-            `deviation` ascending (ties broken on `angle_deviation`), each
-            carrying the tightest sampled `symprec` that produced it. Empty if
-            no tolerance in the range yielded a symmetry. From an explicit
-            `symprec_range`: one level per tolerance, ordered by symprec
-            ascending.
+            One level per distinct space group found, ordered by `deviation`
+            ascending (ties broken on `angle_deviation`), each carrying the
+            tightest sampled `symprec` that produced it. Empty if no tolerance
+            in the range yielded a symmetry.
 
         Raises
         ------
         ValueError
-            If `symprec_range` is combined with any of the scan settings, or if
-            the scan range or sample count is not usable.
+            If the scan range or sample count is not usable.
         """
-        if symprec_range is not None:
-            conflicting = [
-                name
-                for name, value in (
-                    ('symprec_min', symprec_min),
-                    ('symprec_max', symprec_max),
-                    ('n_samples', n_samples),
-                )
-                if value is not None
-            ]
-            if conflicting:
-                listed = ', '.join(f'`{name}`' for name in conflicting)
-                raise ValueError(
-                    f'`symprec_range` lists the tolerances explicitly, so it cannot be '
-                    f'combined with {listed}; those only configure the automatic scan.'
-                )
-            return SymmetryRanking([self._level(symprec) for symprec in sorted(symprec_range)])
-
         symprec_min = 0.01 if symprec_min is None else symprec_min
         symprec_max = 0.5 if symprec_max is None else symprec_max
         n_samples = 40 if n_samples is None else n_samples
@@ -534,3 +511,26 @@ class SymmetryAnalyzer:
         ]
 
         return SymmetryRanking(sorted(thresholds, key=_rank_key))
+
+    def rank_at(self, symprecs: Iterable[float]) -> SymmetryRanking:
+        """Fit the space group at each of the given tolerances.
+
+        Where [rank][gemdat.symmetry.SymmetryAnalyzer.rank] discovers the
+        tolerances itself and reports one level per space group, this reports
+        one level per tolerance handed to it, including repeated space groups.
+        The deviations are not measured, since measuring is
+        operations x sites^2 and a fixed list repeats the same groups.
+
+        Parameters
+        ----------
+        symprecs : Iterable[float]
+            Tolerances (Ångstrom) to evaluate.
+
+        Returns
+        -------
+        SymmetryRanking
+            One level per tolerance, ordered by symprec ascending. A tolerance
+            at which the symmetry search raised is kept, with `None` fields and
+            its `error` set.
+        """
+        return SymmetryRanking([self._level(symprec) for symprec in sorted(symprecs)])

--- a/tests/crystallizer_test.py
+++ b/tests/crystallizer_test.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 from pymatgen.core import Species, Structure
 
-from gemdat.crystallizer import Crystallizer, CrystallizerResult
+from gemdat.crystallizer import Crystallizer, CrystallizerResult, SymmetryLevel
 from gemdat.io import read_cif
 from gemdat.trajectory import Trajectory
 
@@ -112,3 +112,150 @@ def test_framework_rejects_variable_lattice(variable_lattice_trajectory):
 
     with pytest.raises(NotImplementedError, match='variable lattice'):
         crystallizer.crystallize()
+
+
+SYMPREC_RANGE = (0.01, 0.05, 0.1, 0.2, 0.3, 0.5)
+
+
+def test_symmetry_ladder(crystal_trajectory):
+    cr = Crystallizer.from_trajectory(crystal_trajectory, floating_specie='Li', resolution=0.5)
+
+    ladder = cr.symmetry_ladder(symprec_range=SYMPREC_RANGE)
+
+    assert [level.symprec for level in ladder] == sorted(SYMPREC_RANGE)
+    assert all(isinstance(level, SymmetryLevel) for level in ladder)
+    for level in ladder:
+        if level.error is None:
+            assert isinstance(level.spacegroup_number, int)
+            assert isinstance(level.spacegroup_symbol, str)
+            assert isinstance(level.crystal_system, str)
+            assert isinstance(level.n_symmetry_ops, int)
+            assert isinstance(level.n_site_orbits, int)
+        else:
+            assert level.spacegroup_number is None
+
+    # This toy fixture climbs from P1 (#1) at the tightest tolerance to a
+    # higher-symmetry monoclinic cell once symprec is loosened.
+    assert ladder[0].spacegroup_number == 1
+    assert ladder[-1].spacegroup_number > 1
+
+
+def test_crystallize_ladder_and_candidates(crystal_trajectory):
+    cr = Crystallizer.from_trajectory(crystal_trajectory, floating_specie='Li', resolution=0.5)
+
+    result = cr.crystallize(symprec_range=SYMPREC_RANGE)
+
+    assert result.ladder is not None
+    assert len(result.ladder) == len(SYMPREC_RANGE)
+
+    assert result.candidates is not None
+    numbers = [c.spacegroup_number for c in result.candidates]
+    assert numbers == sorted(numbers, reverse=True)
+    assert len(numbers) == len(set(numbers))
+    # the winning space group is the highest-numbered candidate
+    assert numbers[0] == result.spacegroup_number
+    # each candidate is the tightest symprec producing that space group
+    for cand in result.candidates:
+        tighter = [
+            level
+            for level in result.ladder
+            if level.symprec < cand.symprec
+            and level.spacegroup_number == cand.spacegroup_number
+        ]
+        assert not tighter
+
+
+def test_crystallize_explicit_symprec_skips_sweep(crystal_trajectory):
+    cr = Crystallizer.from_trajectory(crystal_trajectory, floating_specie='Li', resolution=0.5)
+
+    result = cr.crystallize(symprec=0.3)
+
+    assert result.symprec == 0.3
+    # no sweep was run
+    assert result.ladder is None
+    assert result.candidates is None
+
+
+def test_crystallize_target_spacegroup_number(crystal_trajectory):
+    cr = Crystallizer.from_trajectory(crystal_trajectory, floating_specie='Li', resolution=0.5)
+
+    baseline = cr.crystallize(symprec_range=SYMPREC_RANGE)
+    target = baseline.spacegroup_number
+
+    result = cr.crystallize(symprec_range=SYMPREC_RANGE, target_spacegroup=target)
+
+    assert result.spacegroup_number == target
+    # tightest symprec in the range that still yields the target
+    assert result.ladder is not None
+    tighter = [
+        level
+        for level in result.ladder
+        if level.symprec < result.symprec and level.spacegroup_number == target
+    ]
+    assert not tighter
+
+
+def test_crystallize_target_spacegroup_symbol(crystal_trajectory):
+    cr = Crystallizer.from_trajectory(crystal_trajectory, floating_specie='Li', resolution=0.5)
+
+    baseline = cr.crystallize(symprec_range=SYMPREC_RANGE)
+    # match tolerant of case/whitespace
+    messy = f'  {baseline.spacegroup_symbol.lower()} '
+
+    result = cr.crystallize(symprec_range=SYMPREC_RANGE, target_spacegroup=messy)
+
+    assert result.spacegroup_number == baseline.spacegroup_number
+
+
+def test_crystallize_target_spacegroup_unreachable(crystal_trajectory):
+    cr = Crystallizer.from_trajectory(crystal_trajectory, floating_specie='Li', resolution=0.5)
+
+    with pytest.raises(ValueError, match='space group 216'):
+        cr.crystallize(symprec_range=SYMPREC_RANGE, target_spacegroup=216)
+
+    # the error lists what was actually found (the ladder table)
+    try:
+        cr.crystallize(symprec_range=SYMPREC_RANGE, target_spacegroup=216)
+    except ValueError as exc:
+        assert 'symprec (Å)' in str(exc)
+
+
+def test_crystallize_symprec_and_target_are_contradictory(crystal_trajectory):
+    cr = Crystallizer.from_trajectory(crystal_trajectory, floating_specie='Li', resolution=0.5)
+
+    with pytest.raises(ValueError, match='not both'):
+        cr.crystallize(symprec=0.1, target_spacegroup=200)
+
+
+def test_crystallize_explicit_symprec_failure_raises(crystal_trajectory):
+    cr = Crystallizer.from_trajectory(crystal_trajectory, floating_specie='Li', resolution=0.5)
+
+    # 0.0 is not a usable tolerance for the symmetry finder
+    with pytest.raises(ValueError, match='symprec=0.0'):
+        cr.crystallize(symprec=0.0)
+
+
+def test_format_ladder(crystal_trajectory):
+    cr = Crystallizer.from_trajectory(crystal_trajectory, floating_specie='Li', resolution=0.5)
+
+    result = cr.crystallize(symprec_range=SYMPREC_RANGE)
+    table = result.format_ladder()
+
+    assert isinstance(table, str)
+    lines = table.splitlines()
+    assert 'symprec (Å)' in lines[0]
+    assert 'space group' in lines[0]
+    assert '# orbits' in lines[0]
+    # header + separator + one row per symprec
+    assert len(lines) == 2 + len(SYMPREC_RANGE)
+    for symprec in SYMPREC_RANGE:
+        assert any(line.startswith(f'{symprec:g}') for line in lines[2:])
+
+
+def test_format_ladder_without_ladder_raises(crystal_trajectory):
+    cr = Crystallizer.from_trajectory(crystal_trajectory, floating_specie='Li', resolution=0.5)
+
+    result = cr.crystallize(symprec=0.3)
+
+    with pytest.raises(ValueError, match='no symmetry ladder'):
+        result.format_ladder()

--- a/tests/crystallizer_test.py
+++ b/tests/crystallizer_test.py
@@ -4,8 +4,9 @@ import numpy as np
 import pytest
 from pymatgen.core import Species, Structure
 
-from gemdat.crystallizer import Crystallizer, CrystallizerResult, SymmetryLevel
+from gemdat.crystallizer import Crystallizer, CrystallizerResult
 from gemdat.io import read_cif
+from gemdat.symmetry import SymmetryLevel, SymmetryRanking
 from gemdat.trajectory import Trajectory
 
 
@@ -72,7 +73,8 @@ def test_crystallize(crystal_trajectory):
     assert isinstance(result.structure, Structure)
     assert len(result.structure) > 0
     assert result.spacegroup_number >= 1
-    assert result.symprec in (0.01, 0.05, 0.1, 0.2, 0.3, 0.5)
+    # the automatic scan reports the tolerance the winning group requires
+    assert 0.01 <= result.symprec <= 0.5
 
 
 def test_crystallize_empty_framework(crystal_trajectory):
@@ -117,14 +119,14 @@ def test_framework_rejects_variable_lattice(variable_lattice_trajectory):
 SYMPREC_RANGE = (0.01, 0.05, 0.1, 0.2, 0.3, 0.5)
 
 
-def test_symmetry_ladder(crystal_trajectory):
+def test_symmetry_ranking_explicit_range(crystal_trajectory):
     cr = Crystallizer.from_trajectory(crystal_trajectory, floating_specie='Li', resolution=0.5)
 
-    ladder = cr.symmetry_ladder(symprec_range=SYMPREC_RANGE)
+    ranking = cr.symmetry_ranking(symprec_range=SYMPREC_RANGE)
 
-    assert [level.symprec for level in ladder] == sorted(SYMPREC_RANGE)
-    assert all(isinstance(level, SymmetryLevel) for level in ladder)
-    for level in ladder:
+    assert [level.symprec for level in ranking] == sorted(SYMPREC_RANGE)
+    assert all(isinstance(level, SymmetryLevel) for level in ranking)
+    for level in ranking:
         if level.error is None:
             assert isinstance(level.spacegroup_number, int)
             assert isinstance(level.spacegroup_symbol, str)
@@ -136,17 +138,48 @@ def test_symmetry_ladder(crystal_trajectory):
 
     # This toy fixture climbs from P1 (#1) at the tightest tolerance to a
     # higher-symmetry monoclinic cell once symprec is loosened.
-    assert ladder[0].spacegroup_number == 1
-    assert ladder[-1].spacegroup_number > 1
+    assert ranking[0].spacegroup_number == 1
+    assert ranking[-1].spacegroup_number > 1
 
 
-def test_crystallize_ladder_and_candidates(crystal_trajectory):
+def test_symmetry_ranking_scans_by_default(crystal_trajectory):
+    cr = Crystallizer.from_trajectory(crystal_trajectory, floating_specie='Li', resolution=0.5)
+
+    ranking = cr.symmetry_ranking(n_samples=20)
+
+    # the scan itself is covered in tests/symmetry_test.py; here it only has to
+    # arrive with the reconstructed geometry
+    assert isinstance(ranking, SymmetryRanking)
+    assert len(ranking) >= 1
+    assert all(level.deviation is not None for level in ranking)
+    assert ranking[0].spacegroup_number == 1
+
+
+def test_crystallize_scan_ranking_and_candidates(crystal_trajectory):
+    cr = Crystallizer.from_trajectory(crystal_trajectory, floating_specie='Li', resolution=0.5)
+
+    result = cr.crystallize(n_samples=20)
+
+    assert result.ranking is not None
+    assert result.candidates is not None
+    # the scan already yields one level per group, so candidates is the same
+    # set, just ranked by space-group number instead of by deviation
+    assert {c.spacegroup_number for c in result.candidates} == {
+        level.spacegroup_number for level in result.ranking
+    }
+    numbers = [c.spacegroup_number for c in result.candidates]
+    assert numbers == sorted(numbers, reverse=True)
+    # the winner is the highest-symmetry candidate
+    assert result.spacegroup_number == numbers[0]
+
+
+def test_crystallize_ranking_and_candidates(crystal_trajectory):
     cr = Crystallizer.from_trajectory(crystal_trajectory, floating_specie='Li', resolution=0.5)
 
     result = cr.crystallize(symprec_range=SYMPREC_RANGE)
 
-    assert result.ladder is not None
-    assert len(result.ladder) == len(SYMPREC_RANGE)
+    assert result.ranking is not None
+    assert len(result.ranking) == len(SYMPREC_RANGE)
 
     assert result.candidates is not None
     numbers = [c.spacegroup_number for c in result.candidates]
@@ -158,7 +191,7 @@ def test_crystallize_ladder_and_candidates(crystal_trajectory):
     for cand in result.candidates:
         tighter = [
             level
-            for level in result.ladder
+            for level in result.ranking
             if level.symprec < cand.symprec
             and level.spacegroup_number == cand.spacegroup_number
         ]
@@ -172,7 +205,7 @@ def test_crystallize_explicit_symprec_skips_sweep(crystal_trajectory):
 
     assert result.symprec == 0.3
     # no sweep was run
-    assert result.ladder is None
+    assert result.ranking is None
     assert result.candidates is None
 
 
@@ -186,10 +219,10 @@ def test_crystallize_target_spacegroup_number(crystal_trajectory):
 
     assert result.spacegroup_number == target
     # tightest symprec in the range that still yields the target
-    assert result.ladder is not None
+    assert result.ranking is not None
     tighter = [
         level
-        for level in result.ladder
+        for level in result.ranking
         if level.symprec < result.symprec and level.spacegroup_number == target
     ]
     assert not tighter
@@ -213,7 +246,7 @@ def test_crystallize_target_spacegroup_unreachable(crystal_trajectory):
     with pytest.raises(ValueError, match='space group 216'):
         cr.crystallize(symprec_range=SYMPREC_RANGE, target_spacegroup=216)
 
-    # the error lists what was actually found (the ladder table)
+    # the error lists what was actually found (the ranking table)
     try:
         cr.crystallize(symprec_range=SYMPREC_RANGE, target_spacegroup=216)
     except ValueError as exc:
@@ -235,11 +268,11 @@ def test_crystallize_explicit_symprec_failure_raises(crystal_trajectory):
         cr.crystallize(symprec=0.0)
 
 
-def test_format_ladder(crystal_trajectory):
+def test_format_ranking(crystal_trajectory):
     cr = Crystallizer.from_trajectory(crystal_trajectory, floating_specie='Li', resolution=0.5)
 
     result = cr.crystallize(symprec_range=SYMPREC_RANGE)
-    table = result.format_ladder()
+    table = result.format_ranking()
 
     assert isinstance(table, str)
     lines = table.splitlines()
@@ -252,10 +285,10 @@ def test_format_ladder(crystal_trajectory):
         assert any(line.startswith(f'{symprec:g}') for line in lines[2:])
 
 
-def test_format_ladder_without_ladder_raises(crystal_trajectory):
+def test_format_ranking_without_ranking_raises(crystal_trajectory):
     cr = Crystallizer.from_trajectory(crystal_trajectory, floating_specie='Li', resolution=0.5)
 
     result = cr.crystallize(symprec=0.3)
 
-    with pytest.raises(ValueError, match='no symmetry ladder'):
-        result.format_ladder()
+    with pytest.raises(ValueError, match='no symmetry ranking'):
+        result.format_ranking()

--- a/tests/crystallizer_test.py
+++ b/tests/crystallizer_test.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import numpy as np
 import pytest
 from pymatgen.core import Species, Structure
 
 from gemdat.crystallizer import Crystallizer, CrystallizerResult
 from gemdat.io import read_cif
-from gemdat.symmetry import SymmetryLevel, SymmetryRanking
+from gemdat.symmetry import SymmetryAnalyzer, SymmetryLevel, SymmetryRanking
 from gemdat.trajectory import Trajectory
 
 
@@ -204,9 +206,10 @@ def test_crystallize_explicit_symprec_skips_sweep(crystal_trajectory):
     result = cr.crystallize(symprec=0.3)
 
     assert result.symprec == 0.3
-    # no sweep was run
+    # no sweep was run, and asking for its results says so
     assert result.ranking is None
-    assert result.candidates is None
+    with pytest.raises(ValueError, match='no symmetry ranking'):
+        result.candidates
 
 
 def test_crystallize_target_spacegroup_number(crystal_trajectory):
@@ -243,21 +246,94 @@ def test_crystallize_target_spacegroup_symbol(crystal_trajectory):
 def test_crystallize_target_spacegroup_unreachable(crystal_trajectory):
     cr = Crystallizer.from_trajectory(crystal_trajectory, floating_specie='Li', resolution=0.5)
 
-    with pytest.raises(ValueError, match='space group 216'):
+    with pytest.raises(ValueError, match='space group 216') as excinfo:
         cr.crystallize(symprec_range=SYMPREC_RANGE, target_spacegroup=216)
 
     # the error lists what was actually found (the ranking table)
-    try:
-        cr.crystallize(symprec_range=SYMPREC_RANGE, target_spacegroup=216)
-    except ValueError as exc:
-        assert 'symprec (Å)' in str(exc)
+    assert 'symprec (Å)' in str(excinfo.value)
 
 
-def test_crystallize_symprec_and_target_are_contradictory(crystal_trajectory):
+@pytest.mark.parametrize(
+    'kwargs',
+    [
+        {'target_spacegroup': 200},
+        {'symprec_range': SYMPREC_RANGE},
+        {'symprec_min': 0.02},
+        {'symprec_max': 0.4},
+        {'n_samples': 10},
+    ],
+)
+def test_crystallize_symprec_conflicts_are_rejected(crystal_trajectory, kwargs):
+    # an explicit symprec makes every sweep setting meaningless; silently
+    # ignoring them would hide a mistake
     cr = Crystallizer.from_trajectory(crystal_trajectory, floating_specie='Li', resolution=0.5)
 
-    with pytest.raises(ValueError, match='not both'):
-        cr.crystallize(symprec=0.1, target_spacegroup=200)
+    with pytest.raises(ValueError, match='cannot be combined'):
+        cr.crystallize(symprec=0.1, **kwargs)
+
+
+@pytest.mark.parametrize(
+    'kwargs', [{'symprec_min': 0.02}, {'symprec_max': 0.4}, {'n_samples': 10}]
+)
+def test_symmetry_ranking_range_conflicts_are_rejected(crystal_trajectory, kwargs):
+    cr = Crystallizer.from_trajectory(crystal_trajectory, floating_specie='Li', resolution=0.5)
+
+    with pytest.raises(ValueError, match='cannot be combined'):
+        cr.symmetry_ranking(symprec_range=SYMPREC_RANGE, **kwargs)
+
+
+def test_crystallize_without_any_symmetry_raises(crystal_trajectory):
+    # 0.0 is not a usable tolerance, so the whole sweep fails
+    cr = Crystallizer.from_trajectory(crystal_trajectory, floating_specie='Li', resolution=0.5)
+
+    with pytest.raises(ValueError, match='Could not determine symmetry for any'):
+        cr.crystallize(symprec_range=(0.0,))
+
+
+def test_crystallize_angle_tolerance_is_used(crystal_trajectory):
+    # a negative angle tolerance switches spglib to its own algorithm rather
+    # than being an error, so check the value arrives at the analyzer
+    cr = Crystallizer.from_trajectory(crystal_trajectory, floating_specie='Li', resolution=0.5)
+
+    seen = []
+    original = SymmetryAnalyzer.__init__
+
+    def record(self, structure, *, angle_tolerance=5.0):
+        seen.append(angle_tolerance)
+        original(self, structure, angle_tolerance=angle_tolerance)
+
+    with patch.object(SymmetryAnalyzer, '__init__', record):
+        cr.crystallize(symprec_range=SYMPREC_RANGE, angle_tolerance=1.0)
+        cr.symmetry_ranking(symprec_range=SYMPREC_RANGE, angle_tolerance=2.0)
+
+    assert seen == [1.0, 2.0]
+
+
+def test_geometry_is_computed_once_per_argument_set(crystal_trajectory):
+    # peak extraction dominates the cost, so repeated calls must reuse it
+    cr = Crystallizer.from_trajectory(crystal_trajectory, floating_specie='Li', resolution=0.5)
+
+    with patch.object(
+        Crystallizer,
+        '_compute_geometry_and_occupancies',
+        autospec=True,
+        side_effect=Crystallizer._compute_geometry_and_occupancies,
+    ) as compute:
+        cr.crystallize(symprec=0.3)
+        cr.crystallize(symprec=0.3)
+        cr.symmetry_ranking(symprec_range=SYMPREC_RANGE)
+        assert compute.call_count == 1
+
+        # different arguments are a different geometry
+        cr.crystallize(symprec=0.3, background_level=0.2)
+        assert compute.call_count == 2
+
+        # unhashable arguments simply bypass the cache (voxel coordinates of
+        # the two Li sites on the 20^3 grid this resolution gives)
+        peaks = np.array([[5, 5, 5], [15, 15, 15]])
+        cr.symmetry_ranking(symprec_range=SYMPREC_RANGE, peaks=peaks)
+        cr.symmetry_ranking(symprec_range=SYMPREC_RANGE, peaks=peaks)
+        assert compute.call_count == 4
 
 
 def test_crystallize_explicit_symprec_failure_raises(crystal_trajectory):

--- a/tests/crystallizer_test.py
+++ b/tests/crystallizer_test.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+from dataclasses import fields, replace
 from unittest.mock import patch
 
 import numpy as np
 import pytest
 from pymatgen.core import Species, Structure
 
-from gemdat.crystallizer import Crystallizer, CrystallizerResult
+from gemdat.crystallizer import Crystallizer, CrystallizerResult, CrystallizerScan
 from gemdat.io import read_cif
 from gemdat.symmetry import SymmetryAnalyzer, SymmetryLevel, SymmetryRanking
 from gemdat.trajectory import Trajectory
@@ -121,10 +122,10 @@ def test_framework_rejects_variable_lattice(variable_lattice_trajectory):
 SYMPREC_RANGE = (0.01, 0.05, 0.1, 0.2, 0.3, 0.5)
 
 
-def test_symmetry_ranking_explicit_range(crystal_trajectory):
+def test_scan_at_lists_the_given_tolerances(crystal_trajectory):
     cr = Crystallizer.from_trajectory(crystal_trajectory, floating_specie='Li', resolution=0.5)
 
-    ranking = cr.symmetry_ranking(symprec_range=SYMPREC_RANGE)
+    ranking = cr.scan_at(SYMPREC_RANGE).ranking
 
     assert [level.symprec for level in ranking] == sorted(SYMPREC_RANGE)
     assert all(isinstance(level, SymmetryLevel) for level in ranking)
@@ -144,150 +145,138 @@ def test_symmetry_ranking_explicit_range(crystal_trajectory):
     assert ranking[-1].spacegroup_number > 1
 
 
-def test_symmetry_ranking_scans_by_default(crystal_trajectory):
+def test_scan_ranks_by_default(crystal_trajectory):
     cr = Crystallizer.from_trajectory(crystal_trajectory, floating_specie='Li', resolution=0.5)
 
-    ranking = cr.symmetry_ranking(n_samples=20)
+    scan = cr.scan(n_samples=20)
 
-    # the scan itself is covered in tests/symmetry_test.py; here it only has to
+    assert isinstance(scan, CrystallizerScan)
+    # the sweep itself is covered in tests/symmetry_test.py; here it only has to
     # arrive with the reconstructed geometry
-    assert isinstance(ranking, SymmetryRanking)
-    assert len(ranking) >= 1
-    assert all(level.deviation is not None for level in ranking)
-    assert ranking[0].spacegroup_number == 1
+    assert isinstance(scan.ranking, SymmetryRanking)
+    assert len(scan.ranking) >= 1
+    assert all(level.deviation is not None for level in scan.ranking)
+    assert scan.ranking[0].spacegroup_number == 1
 
 
-def test_crystallize_scan_ranking_and_candidates(crystal_trajectory):
+def test_scan_candidates_and_best(crystal_trajectory):
     cr = Crystallizer.from_trajectory(crystal_trajectory, floating_specie='Li', resolution=0.5)
 
-    result = cr.crystallize(n_samples=20)
+    scan = cr.scan(n_samples=20)
 
-    assert result.ranking is not None
-    assert result.candidates is not None
-    # the scan already yields one level per group, so candidates is the same
+    # the sweep already yields one level per group, so candidates is the same
     # set, just ranked by space-group number instead of by deviation
-    assert {c.spacegroup_number for c in result.candidates} == {
-        level.spacegroup_number for level in result.ranking
+    assert {c.spacegroup_number for c in scan.candidates} == {
+        level.spacegroup_number for level in scan.ranking
     }
-    numbers = [c.spacegroup_number for c in result.candidates]
+    numbers = [c.spacegroup_number for c in scan.candidates]
     assert numbers == sorted(numbers, reverse=True)
     # the winner is the highest-symmetry candidate
-    assert result.spacegroup_number == numbers[0]
+    assert scan.best().spacegroup_number == numbers[0]
 
 
-def test_crystallize_ranking_and_candidates(crystal_trajectory):
+def test_scan_at_candidates(crystal_trajectory):
     cr = Crystallizer.from_trajectory(crystal_trajectory, floating_specie='Li', resolution=0.5)
 
-    result = cr.crystallize(symprec_range=SYMPREC_RANGE)
+    scan = cr.scan_at(SYMPREC_RANGE)
+    ranking = scan.ranking
 
-    assert result.ranking is not None
-    assert len(result.ranking) == len(SYMPREC_RANGE)
+    assert len(ranking) == len(SYMPREC_RANGE)
+    assert scan.candidates == ranking.candidates
 
-    assert result.candidates is not None
-    numbers = [c.spacegroup_number for c in result.candidates]
+    numbers = [c.spacegroup_number for c in scan.candidates]
     assert numbers == sorted(numbers, reverse=True)
     assert len(numbers) == len(set(numbers))
     # the winning space group is the highest-numbered candidate
-    assert numbers[0] == result.spacegroup_number
+    assert numbers[0] == scan.best().spacegroup_number
     # each candidate is the tightest symprec producing that space group
-    for cand in result.candidates:
+    for cand in scan.candidates:
         tighter = [
             level
-            for level in result.ranking
+            for level in ranking
             if level.symprec < cand.symprec
             and level.spacegroup_number == cand.spacegroup_number
         ]
         assert not tighter
 
 
-def test_crystallize_explicit_symprec_skips_sweep(crystal_trajectory):
+def test_crystallize_at_skips_the_scan(crystal_trajectory):
     cr = Crystallizer.from_trajectory(crystal_trajectory, floating_specie='Li', resolution=0.5)
 
-    result = cr.crystallize(symprec=0.3)
+    with patch.object(SymmetryAnalyzer, 'rank', autospec=True) as rank:
+        result = cr.crystallize_at(0.3)
 
     assert result.symprec == 0.3
-    # no sweep was run, and asking for its results says so
-    assert result.ranking is None
-    with pytest.raises(ValueError, match='no symmetry ranking'):
-        result.candidates
+    # the tolerance was given, so no sweep was run to find one
+    rank.assert_not_called()
 
 
-def test_crystallize_target_spacegroup_number(crystal_trajectory):
+def test_result_is_a_plain_value(crystal_trajectory):
+    # a result holds no scan: another space group is asked of the scan it came
+    # from, never of the result
     cr = Crystallizer.from_trajectory(crystal_trajectory, floating_specie='Li', resolution=0.5)
 
-    baseline = cr.crystallize(symprec_range=SYMPREC_RANGE)
-    target = baseline.spacegroup_number
+    result = cr.crystallize_at(0.3)
 
-    result = cr.crystallize(symprec_range=SYMPREC_RANGE, target_spacegroup=target)
+    assert {field.name for field in fields(result)} == {
+        'structure',
+        'spacegroup_symbol',
+        'spacegroup_number',
+        'symprec',
+    }
+
+
+def test_at_spacegroup_number(crystal_trajectory):
+    cr = Crystallizer.from_trajectory(crystal_trajectory, floating_specie='Li', resolution=0.5)
+
+    scan = cr.scan(n_samples=20)
+    target = scan.best().spacegroup_number
+
+    result = scan.at_spacegroup(target)
 
     assert result.spacegroup_number == target
-    # tightest symprec in the range that still yields the target
-    assert result.ranking is not None
+    # tightest symprec in the scan that still yields the target
     tighter = [
         level
-        for level in result.ranking
+        for level in scan.ranking
         if level.symprec < result.symprec and level.spacegroup_number == target
     ]
     assert not tighter
 
 
-def test_crystallize_target_spacegroup_symbol(crystal_trajectory):
+def test_at_spacegroup_symbol(crystal_trajectory):
     cr = Crystallizer.from_trajectory(crystal_trajectory, floating_specie='Li', resolution=0.5)
 
-    baseline = cr.crystallize(symprec_range=SYMPREC_RANGE)
+    scan = cr.scan(n_samples=20)
+    baseline = scan.best()
     # match tolerant of case/whitespace
     messy = f'  {baseline.spacegroup_symbol.lower()} '
 
-    result = cr.crystallize(symprec_range=SYMPREC_RANGE, target_spacegroup=messy)
+    result = scan.at_spacegroup(messy)
 
     assert result.spacegroup_number == baseline.spacegroup_number
 
 
-def test_crystallize_target_spacegroup_unreachable(crystal_trajectory):
+def test_at_spacegroup_unreachable(crystal_trajectory):
     cr = Crystallizer.from_trajectory(crystal_trajectory, floating_specie='Li', resolution=0.5)
 
+    scan = cr.scan(n_samples=20)
+
     with pytest.raises(ValueError, match='space group 216') as excinfo:
-        cr.crystallize(symprec_range=SYMPREC_RANGE, target_spacegroup=216)
+        scan.at_spacegroup(216)
 
     # the error lists what was actually found (the ranking table)
     assert 'symprec (Å)' in str(excinfo.value)
 
 
-@pytest.mark.parametrize(
-    'kwargs',
-    [
-        {'target_spacegroup': 200},
-        {'symprec_range': SYMPREC_RANGE},
-        {'symprec_min': 0.02},
-        {'symprec_max': 0.4},
-        {'n_samples': 10},
-    ],
-)
-def test_crystallize_symprec_conflicts_are_rejected(crystal_trajectory, kwargs):
-    # an explicit symprec makes every sweep setting meaningless; silently
-    # ignoring them would hide a mistake
+def test_scan_without_any_symmetry_raises(crystal_trajectory):
+    # 0.0 is not a usable tolerance, so every fit in the sweep fails
     cr = Crystallizer.from_trajectory(crystal_trajectory, floating_specie='Li', resolution=0.5)
 
-    with pytest.raises(ValueError, match='cannot be combined'):
-        cr.crystallize(symprec=0.1, **kwargs)
-
-
-@pytest.mark.parametrize(
-    'kwargs', [{'symprec_min': 0.02}, {'symprec_max': 0.4}, {'n_samples': 10}]
-)
-def test_symmetry_ranking_range_conflicts_are_rejected(crystal_trajectory, kwargs):
-    cr = Crystallizer.from_trajectory(crystal_trajectory, floating_specie='Li', resolution=0.5)
-
-    with pytest.raises(ValueError, match='cannot be combined'):
-        cr.symmetry_ranking(symprec_range=SYMPREC_RANGE, **kwargs)
-
-
-def test_crystallize_without_any_symmetry_raises(crystal_trajectory):
-    # 0.0 is not a usable tolerance, so the whole sweep fails
-    cr = Crystallizer.from_trajectory(crystal_trajectory, floating_specie='Li', resolution=0.5)
+    scan = cr.scan_at((0.0,))
 
     with pytest.raises(ValueError, match='Could not determine symmetry for any'):
-        cr.crystallize(symprec_range=(0.0,))
+        scan.best()
 
 
 def test_crystallize_angle_tolerance_is_used(crystal_trajectory):
@@ -303,8 +292,8 @@ def test_crystallize_angle_tolerance_is_used(crystal_trajectory):
         original(self, structure, angle_tolerance=angle_tolerance)
 
     with patch.object(SymmetryAnalyzer, '__init__', record):
-        cr.crystallize(symprec_range=SYMPREC_RANGE, angle_tolerance=1.0)
-        cr.symmetry_ranking(symprec_range=SYMPREC_RANGE, angle_tolerance=2.0)
+        cr.crystallize(n_samples=5, angle_tolerance=1.0)
+        cr.scan_at(SYMPREC_RANGE, angle_tolerance=2.0)
 
     assert seen == [1.0, 2.0]
 
@@ -319,36 +308,35 @@ def test_geometry_is_computed_once_per_argument_set(crystal_trajectory):
         autospec=True,
         side_effect=Crystallizer._compute_geometry_and_occupancies,
     ) as compute:
-        cr.crystallize(symprec=0.3)
-        cr.crystallize(symprec=0.3)
-        cr.symmetry_ranking(symprec_range=SYMPREC_RANGE)
+        cr.crystallize_at(0.3)
+        cr.crystallize_at(0.3)
+        cr.scan_at(SYMPREC_RANGE)
         assert compute.call_count == 1
 
         # different arguments are a different geometry
-        cr.crystallize(symprec=0.3, background_level=0.2)
+        cr.crystallize_at(0.3, background_level=0.2)
         assert compute.call_count == 2
 
         # unhashable arguments simply bypass the cache (voxel coordinates of
         # the two Li sites on the 20^3 grid this resolution gives)
         peaks = np.array([[5, 5, 5], [15, 15, 15]])
-        cr.symmetry_ranking(symprec_range=SYMPREC_RANGE, peaks=peaks)
-        cr.symmetry_ranking(symprec_range=SYMPREC_RANGE, peaks=peaks)
+        cr.scan_at(SYMPREC_RANGE, peaks=peaks)
+        cr.scan_at(SYMPREC_RANGE, peaks=peaks)
         assert compute.call_count == 4
 
 
-def test_crystallize_explicit_symprec_failure_raises(crystal_trajectory):
+def test_crystallize_at_failure_raises(crystal_trajectory):
     cr = Crystallizer.from_trajectory(crystal_trajectory, floating_specie='Li', resolution=0.5)
 
     # 0.0 is not a usable tolerance for the symmetry finder
     with pytest.raises(ValueError, match='symprec=0.0'):
-        cr.crystallize(symprec=0.0)
+        cr.crystallize_at(0.0)
 
 
-def test_format_ranking(crystal_trajectory):
+def test_scan_format(crystal_trajectory):
     cr = Crystallizer.from_trajectory(crystal_trajectory, floating_specie='Li', resolution=0.5)
 
-    result = cr.crystallize(symprec_range=SYMPREC_RANGE)
-    table = result.format_ranking()
+    table = cr.scan_at(SYMPREC_RANGE).format()
 
     assert isinstance(table, str)
     lines = table.splitlines()
@@ -361,10 +349,67 @@ def test_format_ranking(crystal_trajectory):
         assert any(line.startswith(f'{symprec:g}') for line in lines[2:])
 
 
-def test_format_ranking_without_ranking_raises(crystal_trajectory):
+def test_result_to_cif(crystal_trajectory, tmp_path):
+    # a result that has already been inspected writes itself, without refitting
+    cr = Crystallizer.from_trajectory(crystal_trajectory, floating_specie='Li', resolution=0.5)
+    result = cr.crystallize(n_samples=20)
+
+    filename = tmp_path / 'crystallized.cif'
+    result.to_cif(filename)
+
+    assert filename.exists()
+    assert isinstance(read_cif(filename), Structure)
+
+
+def test_at_level(crystal_trajectory):
+    cr = Crystallizer.from_trajectory(crystal_trajectory, floating_specie='Li', resolution=0.5)
+    scan = cr.scan_at(SYMPREC_RANGE)
+
+    # the lowest-symmetry row of the ranking, i.e. not the one `best` picks
+    level = min(scan.ranking.found, key=lambda level: level.spacegroup_number)
+
+    result = scan.at_level(level)
+
+    assert result.spacegroup_number == level.spacegroup_number
+    assert result.spacegroup_symbol == level.spacegroup_symbol
+    assert result.symprec == level.symprec
+
+
+def test_to_cif_per_candidate(crystal_trajectory, tmp_path):
+    cr = Crystallizer.from_trajectory(crystal_trajectory, floating_specie='Li', resolution=0.5)
+    scan = cr.scan_at(SYMPREC_RANGE)
+
+    for level in scan.candidates:
+        filename = tmp_path / f'{level.spacegroup_number}.cif'
+        result = scan.at_level(level)
+        result.to_cif(filename)
+
+        assert filename.exists()
+        assert result.spacegroup_number == level.spacegroup_number
+        assert isinstance(read_cif(filename), Structure)
+
+
+def test_at_level_from_other_scan_raises(crystal_trajectory):
+    cr = Crystallizer.from_trajectory(crystal_trajectory, floating_specie='Li', resolution=0.5)
+    scan = cr.scan_at(SYMPREC_RANGE)
+    level = scan.ranking.best()
+
+    # a level whose space group this geometry does not reproduce cannot have
+    # come from a ranking of it
+    bogus = replace(level, spacegroup_number=216, spacegroup_symbol='F-43m')
+
+    with pytest.raises(ValueError, match='not part of this scan'):
+        scan.at_level(bogus)
+
+
+def test_at_level_failed_raises(crystal_trajectory):
     cr = Crystallizer.from_trajectory(crystal_trajectory, floating_specie='Li', resolution=0.5)
 
-    result = cr.crystallize(symprec=0.3)
+    # 0.0 is not a usable tolerance, so the only row of this scan failed
+    scan = cr.scan_at((0.0,))
+    (failed,) = scan.ranking
 
-    with pytest.raises(ValueError, match='no symmetry ranking'):
-        result.format_ranking()
+    assert failed.error is not None
+
+    with pytest.raises(ValueError, match='found no space group'):
+        scan.at_level(failed)

--- a/tests/symmetry_test.py
+++ b/tests/symmetry_test.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+from dataclasses import replace
+from types import SimpleNamespace
+
+import numpy as np
 import pytest
 from pymatgen.core import Lattice, Structure
 
-from gemdat.symmetry import SymmetryAnalyzer, SymmetryLevel, SymmetryRanking
+from gemdat.symmetry import SymmetryAnalyzer, SymmetryLevel, SymmetryRanking, _rank_key
 
 SYMPREC_RANGE = (0.01, 0.05, 0.1, 0.2, 0.3, 0.5)
 
@@ -29,6 +33,17 @@ def ideal_structure():
 @pytest.fixture()
 def noisy_structure():
     return _structure(perturb=0.05)
+
+
+@pytest.fixture()
+def sheared_structure():
+    """A cubic-content cell whose gamma angle is off by exactly 2 degrees, so
+    that the angular cost of fitting it as cubic is known analytically."""
+    return Structure(
+        lattice=Lattice.from_parameters(10.0, 10.0, 10.0, 90.0, 90.0, 92.0),
+        species=['Li', 'Cl'],
+        coords=[[0.0, 0.0, 0.0], [0.5, 0.5, 0.5]],
+    )
 
 
 def _level(number, symbol, symprec=0.1, **kwargs):
@@ -75,6 +90,84 @@ def test_level_with_deviation(ideal_structure):
     assert level.angle_deviation == pytest.approx(0.0, abs=1e-9)
 
 
+def test_deviation_is_the_displacement_the_group_demands():
+    # Cl sits 0.2 A off the body centre along x. The cubic group contains
+    # x -> -x about the origin, which maps it onto its mirror image 0.4 A
+    # away, so that is exactly what the fit costs.
+    structure = Structure(
+        lattice=Lattice.cubic(10.0),
+        species=['Li', 'Cl'],
+        coords=[[0.0, 0.0, 0.0], [0.52, 0.5, 0.5]],
+    )
+
+    level = SymmetryAnalyzer(structure).level(0.5, with_deviation=True)
+
+    assert level.spacegroup_number == 221
+    assert level.deviation == pytest.approx(0.4)
+    assert level.angle_deviation == pytest.approx(0.0, abs=1e-9)
+
+
+def test_angle_deviation_is_the_angle_the_group_demands(sheared_structure):
+    # fitting a gamma = 92 deg cell as cubic idealises gamma back to 90 deg
+    level = SymmetryAnalyzer(sheared_structure).level(0.1, with_deviation=True)
+
+    assert level.spacegroup_number == 221
+    assert level.angle_deviation == pytest.approx(2.0)
+    # the atoms themselves do not have to move for it
+    assert level.deviation == pytest.approx(0.0, abs=1e-9)
+
+
+def test_angle_tolerance_is_honoured(sheared_structure):
+    # 2 deg of shear is within the default tolerance, but not within 1 deg
+    loose = SymmetryAnalyzer(sheared_structure, angle_tolerance=5.0).level(0.1)
+    tight = SymmetryAnalyzer(sheared_structure, angle_tolerance=1.0).level(0.1)
+
+    assert loose.spacegroup_number == 221
+    assert tight.spacegroup_number is not None
+    assert tight.spacegroup_number < loose.spacegroup_number
+
+
+def test_deviation_matches_sites_one_to_one():
+    # A degenerate operation that collapses both sites onto one point: taking
+    # each image's nearest site would report 0.2 A (both images land next to
+    # Li), but an operation permutes the sites, and no permutation does better
+    # than the 2.8 A of moving one image onto the second site.
+    structure = Structure(
+        lattice=Lattice.cubic(10.0),
+        species=['Li', 'Li'],
+        coords=[[0.0, 0.0, 0.0], [0.3, 0.0, 0.0]],
+    )
+    dataset = SimpleNamespace(
+        rotations=[np.zeros((3, 3), dtype=int)],
+        translations=[np.array([0.02, 0.0, 0.0])],
+        std_lattice=structure.lattice.matrix,
+        std_rotation_matrix=np.eye(3),
+        transformation_matrix=np.eye(3),
+    )
+
+    deviation, angle_deviation, error = SymmetryAnalyzer(structure)._deviation(dataset)
+
+    assert error is None
+    assert deviation == pytest.approx(2.8)
+    assert angle_deviation == pytest.approx(0.0, abs=1e-9)
+
+
+def test_deviation_failure_is_recorded_on_the_level(ideal_structure, monkeypatch):
+    # the deviation is a diagnostic: a failure to measure it must not throw the
+    # space group away, but must not pass silently either
+    monkeypatch.setattr(
+        'gemdat.symmetry.linear_sum_assignment',
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError('boom')),
+    )
+
+    level = SymmetryAnalyzer(ideal_structure).level(0.1, with_deviation=True)
+
+    assert level.spacegroup_number is not None
+    assert level.deviation is None
+    assert level.angle_deviation is None
+    assert 'boom' in level.error
+
+
 def test_scan(noisy_structure):
     ranking = SymmetryAnalyzer(noisy_structure).scan(symprec_min=0.01, symprec_max=0.5)
 
@@ -106,15 +199,58 @@ def test_scan_deviation_is_independent_of_symprec(noisy_structure):
     """The deviation is a property of the structure, so the tolerance that
     happened to find the group must not change it."""
     analyzer = SymmetryAnalyzer(noisy_structure)
-    highest = analyzer.scan(symprec_min=0.01, symprec_max=0.5)[-1]
-    assert highest.spacegroup_number is not None and highest.spacegroup_number > 1
+    winner = analyzer.scan(symprec_min=0.01, symprec_max=0.5).best()
+    assert winner.spacegroup_number is not None and winner.spacegroup_number > 1
 
-    for symprec in (highest.symprec, 0.3, 0.5):
+    compared = 0
+    for symprec in (winner.symprec, 0.3, 0.5):
         level = analyzer.level(symprec, with_deviation=True)
-        if level.spacegroup_number != highest.spacegroup_number:
+        if level.spacegroup_number != winner.spacegroup_number:
             continue
-        assert level.deviation == pytest.approx(highest.deviation)
-        assert level.angle_deviation == pytest.approx(highest.angle_deviation)
+        assert level.deviation == pytest.approx(winner.deviation)
+        assert level.angle_deviation == pytest.approx(winner.angle_deviation)
+        compared += 1
+
+    # the group need not turn up at every tolerance, but if it never did the
+    # loop above would assert nothing at all
+    assert compared
+
+
+def test_scan_orders_unmeasurable_deviations_last(noisy_structure, monkeypatch):
+    analyzer = SymmetryAnalyzer(noisy_structure)
+    real_level = SymmetryAnalyzer.level
+
+    def flaky(self, symprec, *, with_deviation=False):
+        level = real_level(self, symprec, with_deviation=with_deviation)
+        # P1 holds exactly, so it would otherwise sort first
+        if with_deviation and level.spacegroup_number == 1:
+            return replace(level, deviation=None, angle_deviation=None, error='no idea')
+        return level
+
+    monkeypatch.setattr(SymmetryAnalyzer, 'level', flaky)
+
+    ranking = analyzer.scan(symprec_min=0.01, symprec_max=0.5)
+
+    assert len(ranking) > 1
+    assert ranking[-1].spacegroup_number == 1
+    assert ranking[-1].deviation is None
+    # the failure is reported rather than looking like "not measured"
+    assert ranking[-1].error == 'no idea'
+
+
+def test_scan_breaks_deviation_ties_on_the_angle():
+    ranking = SymmetryRanking(
+        sorted(
+            [
+                _level(12, 'C2/m', deviation=0.1, angle_deviation=1.0),
+                _level(65, 'Cmmm', deviation=0.1, angle_deviation=0.2),
+                _level(1, 'P1', deviation=0.0, angle_deviation=0.0),
+            ],
+            key=_rank_key,
+        )
+    )
+
+    assert [level.spacegroup_number for level in ranking] == [1, 65, 12]
 
 
 def test_scan_rejects_invalid_range(ideal_structure):
@@ -128,6 +264,30 @@ def test_scan_rejects_invalid_range(ideal_structure):
 
     with pytest.raises(ValueError, match='`n_samples` must be at least 2'):
         analyzer.scan(n_samples=1)
+
+
+def test_rank_dispatches_on_symprec_range(noisy_structure):
+    analyzer = SymmetryAnalyzer(noisy_structure)
+
+    # a fixed list of tolerances is swept as given...
+    listed = analyzer.rank(symprec_range=SYMPREC_RANGE)
+    assert [level.symprec for level in listed] == sorted(SYMPREC_RANGE)
+    assert all(level.deviation is None for level in listed)
+
+    # ...otherwise the range is scanned and the deviations measured
+    scanned = analyzer.rank(n_samples=10)
+    assert all(level.deviation is not None for level in scanned)
+
+
+@pytest.mark.parametrize(
+    'kwargs', [{'symprec_min': 0.02}, {'symprec_max': 0.4}, {'n_samples': 10}]
+)
+def test_rank_rejects_scan_settings_with_an_explicit_range(ideal_structure, kwargs):
+    # silently ignoring the scan settings would hide a mistake
+    analyzer = SymmetryAnalyzer(ideal_structure)
+
+    with pytest.raises(ValueError, match='cannot be combined'):
+        analyzer.rank(symprec_range=SYMPREC_RANGE, **kwargs)
 
 
 def test_levels_skips_deviation(noisy_structure):
@@ -191,6 +351,15 @@ def test_ranking_match():
     assert ranking.match('F-43m') is None
 
 
+def test_ranking_match_ignores_levels_without_a_symbol():
+    # a level can carry a number but no symbol; matching by symbol must skip it
+    # instead of tripping over the `None`
+    ranking = SymmetryRanking([_level(12, None, symprec=0.1)])
+
+    assert ranking.match('C2/m') is None
+    assert ranking.match(12) is not None
+
+
 def test_ranking_best_prefers_symmetry_then_tightness():
     ranking = SymmetryRanking(
         [
@@ -213,6 +382,20 @@ def test_ranking_best_without_symmetry_raises():
         ranking.best()
 
 
+def test_empty_ranking():
+    ranking = SymmetryRanking([])
+
+    assert len(ranking) == 0
+    assert ranking.found == []
+    assert ranking.candidates == []
+    assert repr(ranking) == 'SymmetryRanking()'
+    # just the header and its underline
+    assert len(ranking.format().splitlines()) == 2
+
+    with pytest.raises(ValueError, match='Could not determine symmetry'):
+        ranking.best()
+
+
 def test_ranking_format():
     ranking = SymmetryRanking(
         [
@@ -226,7 +409,15 @@ def test_ranking_format():
     table = ranking.format()
     lines = table.splitlines()
 
-    for header in ('symprec (Å)', 'deviation (Å)', 'angle dev (°)', 'space group', '# orbits'):
+    for header in (
+        'symprec (Å)',
+        'deviation (Å)',
+        'angle dev (°)',
+        'space group',
+        '# ops',
+        '# orbits',
+        '# hits',
+    ):
         assert header in lines[0]
     # header + separator + one row per level
     assert len(lines) == 4

--- a/tests/symmetry_test.py
+++ b/tests/symmetry_test.py
@@ -59,7 +59,7 @@ def _level(number, symbol, symprec=0.1, **kwargs):
 
 
 def test_level(ideal_structure):
-    level = SymmetryAnalyzer(ideal_structure).level(0.1)
+    level = SymmetryAnalyzer(ideal_structure)._level(0.1)
 
     assert isinstance(level, SymmetryLevel)
     assert level.symprec == 0.1
@@ -75,7 +75,7 @@ def test_level(ideal_structure):
 
 
 def test_level_records_failure_instead_of_raising(ideal_structure):
-    level = SymmetryAnalyzer(ideal_structure).level(0.0)
+    level = SymmetryAnalyzer(ideal_structure)._level(0.0)
 
     assert level.symprec == 0.0
     assert level.spacegroup_number is None
@@ -83,7 +83,7 @@ def test_level_records_failure_instead_of_raising(ideal_structure):
 
 
 def test_level_with_deviation(ideal_structure):
-    level = SymmetryAnalyzer(ideal_structure).level(0.1, with_deviation=True)
+    level = SymmetryAnalyzer(ideal_structure)._level(0.1, with_deviation=True)
 
     # an undistorted structure satisfies its own symmetry exactly
     assert level.deviation == pytest.approx(0.0, abs=1e-9)
@@ -100,7 +100,7 @@ def test_deviation_is_the_displacement_the_group_demands():
         coords=[[0.0, 0.0, 0.0], [0.52, 0.5, 0.5]],
     )
 
-    level = SymmetryAnalyzer(structure).level(0.5, with_deviation=True)
+    level = SymmetryAnalyzer(structure)._level(0.5, with_deviation=True)
 
     assert level.spacegroup_number == 221
     assert level.deviation == pytest.approx(0.4)
@@ -109,7 +109,7 @@ def test_deviation_is_the_displacement_the_group_demands():
 
 def test_angle_deviation_is_the_angle_the_group_demands(sheared_structure):
     # fitting a gamma = 92 deg cell as cubic idealises gamma back to 90 deg
-    level = SymmetryAnalyzer(sheared_structure).level(0.1, with_deviation=True)
+    level = SymmetryAnalyzer(sheared_structure)._level(0.1, with_deviation=True)
 
     assert level.spacegroup_number == 221
     assert level.angle_deviation == pytest.approx(2.0)
@@ -119,8 +119,8 @@ def test_angle_deviation_is_the_angle_the_group_demands(sheared_structure):
 
 def test_angle_tolerance_is_honoured(sheared_structure):
     # 2 deg of shear is within the default tolerance, but not within 1 deg
-    loose = SymmetryAnalyzer(sheared_structure, angle_tolerance=5.0).level(0.1)
-    tight = SymmetryAnalyzer(sheared_structure, angle_tolerance=1.0).level(0.1)
+    loose = SymmetryAnalyzer(sheared_structure, angle_tolerance=5.0)._level(0.1)
+    tight = SymmetryAnalyzer(sheared_structure, angle_tolerance=1.0)._level(0.1)
 
     assert loose.spacegroup_number == 221
     assert tight.spacegroup_number is not None
@@ -160,7 +160,7 @@ def test_deviation_failure_is_recorded_on_the_level(ideal_structure, monkeypatch
         lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError('boom')),
     )
 
-    level = SymmetryAnalyzer(ideal_structure).level(0.1, with_deviation=True)
+    level = SymmetryAnalyzer(ideal_structure)._level(0.1, with_deviation=True)
 
     assert level.spacegroup_number is not None
     assert level.deviation is None
@@ -169,7 +169,7 @@ def test_deviation_failure_is_recorded_on_the_level(ideal_structure, monkeypatch
 
 
 def test_scan(noisy_structure):
-    ranking = SymmetryAnalyzer(noisy_structure).scan(symprec_min=0.01, symprec_max=0.5)
+    ranking = SymmetryAnalyzer(noisy_structure).rank(symprec_min=0.01, symprec_max=0.5)
 
     assert isinstance(ranking, SymmetryRanking)
 
@@ -199,12 +199,12 @@ def test_scan_deviation_is_independent_of_symprec(noisy_structure):
     """The deviation is a property of the structure, so the tolerance that
     happened to find the group must not change it."""
     analyzer = SymmetryAnalyzer(noisy_structure)
-    winner = analyzer.scan(symprec_min=0.01, symprec_max=0.5).best()
+    winner = analyzer.rank(symprec_min=0.01, symprec_max=0.5).best()
     assert winner.spacegroup_number is not None and winner.spacegroup_number > 1
 
     compared = 0
     for symprec in (winner.symprec, 0.3, 0.5):
-        level = analyzer.level(symprec, with_deviation=True)
+        level = analyzer._level(symprec, with_deviation=True)
         if level.spacegroup_number != winner.spacegroup_number:
             continue
         assert level.deviation == pytest.approx(winner.deviation)
@@ -218,7 +218,7 @@ def test_scan_deviation_is_independent_of_symprec(noisy_structure):
 
 def test_scan_orders_unmeasurable_deviations_last(noisy_structure, monkeypatch):
     analyzer = SymmetryAnalyzer(noisy_structure)
-    real_level = SymmetryAnalyzer.level
+    real_level = SymmetryAnalyzer._level
 
     def flaky(self, symprec, *, with_deviation=False):
         level = real_level(self, symprec, with_deviation=with_deviation)
@@ -227,9 +227,9 @@ def test_scan_orders_unmeasurable_deviations_last(noisy_structure, monkeypatch):
             return replace(level, deviation=None, angle_deviation=None, error='no idea')
         return level
 
-    monkeypatch.setattr(SymmetryAnalyzer, 'level', flaky)
+    monkeypatch.setattr(SymmetryAnalyzer, '_level', flaky)
 
-    ranking = analyzer.scan(symprec_min=0.01, symprec_max=0.5)
+    ranking = analyzer.rank(symprec_min=0.01, symprec_max=0.5)
 
     assert len(ranking) > 1
     assert ranking[-1].spacegroup_number == 1
@@ -257,13 +257,13 @@ def test_scan_rejects_invalid_range(ideal_structure):
     analyzer = SymmetryAnalyzer(ideal_structure)
 
     with pytest.raises(ValueError, match='`symprec_min` must be positive'):
-        analyzer.scan(symprec_min=0.0)
+        analyzer.rank(symprec_min=0.0)
 
     with pytest.raises(ValueError, match='must not be smaller'):
-        analyzer.scan(symprec_min=0.5, symprec_max=0.1)
+        analyzer.rank(symprec_min=0.5, symprec_max=0.1)
 
     with pytest.raises(ValueError, match='`n_samples` must be at least 2'):
-        analyzer.scan(n_samples=1)
+        analyzer.rank(n_samples=1)
 
 
 def test_rank_dispatches_on_symprec_range(noisy_structure):
@@ -290,8 +290,8 @@ def test_rank_rejects_scan_settings_with_an_explicit_range(ideal_structure, kwar
         analyzer.rank(symprec_range=SYMPREC_RANGE, **kwargs)
 
 
-def test_levels_skips_deviation(noisy_structure):
-    ranking = SymmetryAnalyzer(noisy_structure).levels(SYMPREC_RANGE)
+def test_explicit_range_skips_deviation(noisy_structure):
+    ranking = SymmetryAnalyzer(noisy_structure).rank(symprec_range=SYMPREC_RANGE)
 
     assert [level.symprec for level in ranking] == sorted(SYMPREC_RANGE)
     # measuring is operations x sites^2, so a plain sweep does not do it

--- a/tests/symmetry_test.py
+++ b/tests/symmetry_test.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import pytest
+from pymatgen.core import Lattice, Structure
+
+from gemdat.symmetry import SymmetryAnalyzer, SymmetryLevel, SymmetryRanking
+
+SYMPREC_RANGE = (0.01, 0.05, 0.1, 0.2, 0.3, 0.5)
+
+
+def _structure(perturb: float | None = None) -> Structure:
+    """A small P/S framework with two Li sites, optionally jittered so that it
+    only reaches its symmetry once the tolerance is loosened."""
+    structure = Structure(
+        lattice=Lattice.cubic(10.0),
+        species=['P', 'S', 'Li', 'Li'],
+        coords=[[0.0, 0.0, 0.0], [0.5, 0.5, 0.0], [0.25, 0.25, 0.25], [0.75, 0.75, 0.75]],
+    )
+    if perturb is not None:
+        structure.perturb(perturb, seed=0)
+    return structure
+
+
+@pytest.fixture()
+def ideal_structure():
+    return _structure()
+
+
+@pytest.fixture()
+def noisy_structure():
+    return _structure(perturb=0.05)
+
+
+def _level(number, symbol, symprec=0.1, **kwargs):
+    return SymmetryLevel(
+        symprec=symprec,
+        spacegroup_number=number,
+        spacegroup_symbol=symbol,
+        crystal_system='cubic',
+        n_symmetry_ops=1,
+        n_site_orbits=1,
+        **kwargs,
+    )
+
+
+def test_level(ideal_structure):
+    level = SymmetryAnalyzer(ideal_structure).level(0.1)
+
+    assert isinstance(level, SymmetryLevel)
+    assert level.symprec == 0.1
+    assert isinstance(level.spacegroup_number, int)
+    assert isinstance(level.spacegroup_symbol, str)
+    assert isinstance(level.crystal_system, str)
+    assert isinstance(level.n_symmetry_ops, int)
+    assert isinstance(level.n_site_orbits, int)
+    assert level.error is None
+    # measuring the deviation is opt-in
+    assert level.deviation is None
+    assert level.angle_deviation is None
+
+
+def test_level_records_failure_instead_of_raising(ideal_structure):
+    level = SymmetryAnalyzer(ideal_structure).level(0.0)
+
+    assert level.symprec == 0.0
+    assert level.spacegroup_number is None
+    assert level.error
+
+
+def test_level_with_deviation(ideal_structure):
+    level = SymmetryAnalyzer(ideal_structure).level(0.1, with_deviation=True)
+
+    # an undistorted structure satisfies its own symmetry exactly
+    assert level.deviation == pytest.approx(0.0, abs=1e-9)
+    assert level.angle_deviation == pytest.approx(0.0, abs=1e-9)
+
+
+def test_scan(noisy_structure):
+    ranking = SymmetryAnalyzer(noisy_structure).scan(symprec_min=0.01, symprec_max=0.5)
+
+    assert isinstance(ranking, SymmetryRanking)
+
+    # one entry per distinct space group, least demanding first
+    numbers = [level.spacegroup_number for level in ranking]
+    assert len(numbers) == len(set(numbers))
+    assert [level.deviation for level in ranking] == sorted(
+        level.deviation for level in ranking
+    )
+
+    for level in ranking:
+        assert 0.01 <= level.symprec <= 0.5
+        assert level.error is None
+        assert level.deviation is not None and level.deviation >= 0
+        assert level.angle_deviation is not None and level.angle_deviation >= 0
+        assert level.n_observed is not None and level.n_observed >= 1
+
+    # P1 is always satisfied exactly, so it demands nothing; the jitter has to
+    # be absorbed before any higher symmetry holds
+    assert ranking[0].spacegroup_number == 1
+    assert ranking[0].deviation == pytest.approx(0.0, abs=1e-9)
+    assert all(level.deviation > 0 for level in ranking[1:])
+    assert max(numbers) > 1
+
+
+def test_scan_deviation_is_independent_of_symprec(noisy_structure):
+    """The deviation is a property of the structure, so the tolerance that
+    happened to find the group must not change it."""
+    analyzer = SymmetryAnalyzer(noisy_structure)
+    highest = analyzer.scan(symprec_min=0.01, symprec_max=0.5)[-1]
+    assert highest.spacegroup_number is not None and highest.spacegroup_number > 1
+
+    for symprec in (highest.symprec, 0.3, 0.5):
+        level = analyzer.level(symprec, with_deviation=True)
+        if level.spacegroup_number != highest.spacegroup_number:
+            continue
+        assert level.deviation == pytest.approx(highest.deviation)
+        assert level.angle_deviation == pytest.approx(highest.angle_deviation)
+
+
+def test_scan_rejects_invalid_range(ideal_structure):
+    analyzer = SymmetryAnalyzer(ideal_structure)
+
+    with pytest.raises(ValueError, match='`symprec_min` must be positive'):
+        analyzer.scan(symprec_min=0.0)
+
+    with pytest.raises(ValueError, match='must not be smaller'):
+        analyzer.scan(symprec_min=0.5, symprec_max=0.1)
+
+    with pytest.raises(ValueError, match='`n_samples` must be at least 2'):
+        analyzer.scan(n_samples=1)
+
+
+def test_levels_skips_deviation(noisy_structure):
+    ranking = SymmetryAnalyzer(noisy_structure).levels(SYMPREC_RANGE)
+
+    assert [level.symprec for level in ranking] == sorted(SYMPREC_RANGE)
+    # measuring is operations x sites^2, so a plain sweep does not do it
+    assert all(level.deviation is None for level in ranking)
+    assert all(level.n_observed is None for level in ranking)
+
+
+def test_ranking_is_a_sequence():
+    levels = [_level(1, 'P1'), _level(12, 'C2/m')]
+
+    ranking = SymmetryRanking(levels)
+
+    assert len(ranking) == 2
+    assert list(ranking) == levels
+    assert ranking[0] is levels[0]
+    assert ranking[-1] is levels[-1]
+    assert 'C2/m (12)' in repr(ranking)
+
+
+def test_ranking_found_drops_failures():
+    failed = SymmetryLevel(symprec=0.0, error='nope')
+
+    ranking = SymmetryRanking([failed, _level(12, 'C2/m')])
+
+    assert ranking.found == [ranking[1]]
+
+
+def test_ranking_candidates():
+    ranking = SymmetryRanking(
+        [
+            _level(1, 'P1', symprec=0.01),
+            _level(12, 'C2/m', symprec=0.1),
+            _level(12, 'C2/m', symprec=0.2),
+            SymmetryLevel(symprec=0.3, error='nope'),
+        ]
+    )
+
+    candidates = ranking.candidates
+
+    # one entry per group, highest first, each at its tightest tolerance
+    assert [c.spacegroup_number for c in candidates] == [12, 1]
+    assert [c.symprec for c in candidates] == [0.1, 0.01]
+
+
+def test_ranking_match():
+    ranking = SymmetryRanking(
+        [_level(12, 'C2/m', symprec=0.2), _level(12, 'C2/m', symprec=0.1)]
+    )
+
+    # tightest tolerance reaching the target, by number or by symbol
+    assert ranking.match(12).symprec == 0.1
+    assert ranking.match('C2/m').symprec == 0.1
+    # symbol matching ignores case and whitespace
+    assert ranking.match('  c2/m ').symprec == 0.1
+
+    assert ranking.match(216) is None
+    assert ranking.match('F-43m') is None
+
+
+def test_ranking_best_prefers_symmetry_then_tightness():
+    ranking = SymmetryRanking(
+        [
+            _level(1, 'P1', symprec=0.01),
+            _level(12, 'C2/m', symprec=0.3),
+            _level(12, 'C2/m', symprec=0.1),
+        ]
+    )
+
+    best = ranking.best()
+
+    assert best.spacegroup_number == 12
+    assert best.symprec == 0.1
+
+
+def test_ranking_best_without_symmetry_raises():
+    ranking = SymmetryRanking([SymmetryLevel(symprec=0.0, error='nope')])
+
+    with pytest.raises(ValueError, match='Could not determine symmetry'):
+        ranking.best()
+
+
+def test_ranking_format():
+    ranking = SymmetryRanking(
+        [
+            _level(
+                12, 'C2/m', symprec=0.1, deviation=0.0715, angle_deviation=0.7, n_observed=4
+            ),
+            SymmetryLevel(symprec=0.3, error='nope'),
+        ]
+    )
+
+    table = ranking.format()
+    lines = table.splitlines()
+
+    for header in ('symprec (Å)', 'deviation (Å)', 'angle dev (°)', 'space group', '# orbits'):
+        assert header in lines[0]
+    # header + separator + one row per level
+    assert len(lines) == 4
+    assert lines[2].startswith('0.1')
+    assert 'C2/m' in lines[2]
+    assert '0.0715' in lines[2]
+    # a level whose search failed is shown as such, with empty columns
+    assert 'failed' in lines[3]

--- a/tests/symmetry_test.py
+++ b/tests/symmetry_test.py
@@ -266,35 +266,24 @@ def test_scan_rejects_invalid_range(ideal_structure):
         analyzer.rank(n_samples=1)
 
 
-def test_rank_dispatches_on_symprec_range(noisy_structure):
+def test_rank_at_lists_the_given_tolerances(noisy_structure):
     analyzer = SymmetryAnalyzer(noisy_structure)
 
-    # a fixed list of tolerances is swept as given...
-    listed = analyzer.rank(symprec_range=SYMPREC_RANGE)
+    # a fixed list of tolerances is fitted as given...
+    listed = analyzer.rank_at(SYMPREC_RANGE)
     assert [level.symprec for level in listed] == sorted(SYMPREC_RANGE)
     assert all(level.deviation is None for level in listed)
 
-    # ...otherwise the range is scanned and the deviations measured
+    # ...while the scan finds its own and measures the deviations
     scanned = analyzer.rank(n_samples=10)
     assert all(level.deviation is not None for level in scanned)
 
 
-@pytest.mark.parametrize(
-    'kwargs', [{'symprec_min': 0.02}, {'symprec_max': 0.4}, {'n_samples': 10}]
-)
-def test_rank_rejects_scan_settings_with_an_explicit_range(ideal_structure, kwargs):
-    # silently ignoring the scan settings would hide a mistake
-    analyzer = SymmetryAnalyzer(ideal_structure)
-
-    with pytest.raises(ValueError, match='cannot be combined'):
-        analyzer.rank(symprec_range=SYMPREC_RANGE, **kwargs)
-
-
-def test_explicit_range_skips_deviation(noisy_structure):
-    ranking = SymmetryAnalyzer(noisy_structure).rank(symprec_range=SYMPREC_RANGE)
+def test_rank_at_skips_deviation(noisy_structure):
+    ranking = SymmetryAnalyzer(noisy_structure).rank_at(SYMPREC_RANGE)
 
     assert [level.symprec for level in ranking] == sorted(SYMPREC_RANGE)
-    # measuring is operations x sites^2, so a plain sweep does not do it
+    # measuring is operations x sites^2, so a plain list of tolerances skips it
     assert all(level.deviation is None for level in ranking)
     assert all(level.n_observed is None for level in ranking)
 


### PR DESCRIPTION
Addresses #421 points 1 ("can we give a Top-X? or can we _set_ it if we are sure what it should be") and 5 ("can we show groups of subsymmetries, and at which precision (in Å)"). 

The symmetry fitting now lives in its own module, `gemdat/symmetry.py`, where `SymmetryAnalyzer.rank()` enumerates the space groups reachable over a log-spaced tolerance grid and *measures* each one`deviation`  instead of ranking by symprec.

On the crystallizer side, choosing a group is now two steps: `scan()`/`scan_at()` return a `CrystallizerScan` (the reconstructed geometry plus its `SymmetryRanking`), and returns a plain `CrystallizerResult`, so several groups can be inspected in one scan while the expensive geometry is built and cached once. The `crystallize()`/`to_cif()` shortcuts keep working as before.

Added functionality:

- `gemdat.symmetry` — `SymmetryAnalyzer`, `SymmetryRanking` and `SymmetryLevel`: `rank()` scans a tolerance range and returns one measured level per space group, `rank_at(symprecs)` fits a fixed list of tolerances, and the ranking is a read-only sequence with `.found`, `.candidates` (Top-X, by number descending), `.match(target)`, `.best()` and `.format()`.
- `Crystallizer.scan()` / `scan_at(symprecs)` return a `CrystallizerScan` carrying the geometry and its ranking, plus `.candidates` and `.format()` for the "which subsymmetries, at which precision" table.
- `Crystallizer.crystallize_at(symprec)` fits at exactly that tolerance with no scan at all; `crystallize()` is now `scan().best()` and `to_cif()` is that plus `CrystallizerResult.to_cif`, and any other fit is written via the scan (e.g. `cr.scan().at_spacegroup('Cm').to_cif(...)`).
- The geometry (framework + density peak extraction) is cached per argument set, so repeated `crystallize*`/`scan*`/`to_cif` calls on one `Crystallizer` are cheap and each extra group picked off a scan costs a single symmetry fit; new unit tests cover both modules (`tests/symmetry_test.py`, `tests/crystallizer_test.py`) and the API docs gained a `gemdat.symmetry` page.
