### PR TITLE
Crystallizer: use_density toggle for occupancy incorporation (#421 pt 4)

### DIFF
--- a/src/gemdat/crystallizer.py
+++ b/src/gemdat/crystallizer.py
@@ -35,19 +35,14 @@ class CrystallizerResult:
     ----------
     structure : Structure
         Full structure (static framework + density-derived mobile sites), with
-        occupancies averaged over symmetry-equivalent sites. If ``use_density``
-        is True the mobile sites carry their density-derived partial
-        occupancies (the MD time-fraction the site is occupied); if False every
-        mobile site is emitted at full occupancy 1.0 and the structure is the
-        idealised site framework without MD occupancy statistics. Framework
-        sites are always fully occupied.
+        occupancies averaged over symmetry-equivalent sites.
     spacegroup_symbol : str
         International symbol of the fitted space group.
     spacegroup_number : int
         International number of the fitted space group.
     symprec : float
         Symmetry tolerance (in Ångstrom) that produced the fit.
-    use_density : bool
+    has_partial_occupancies : bool
         Whether density-derived partial occupancies were written into
         ``structure`` (True) or every mobile site was set to full occupancy
         (False).
@@ -57,7 +52,7 @@ class CrystallizerResult:
     spacegroup_symbol: str
     spacegroup_number: int
     symprec: float
-    use_density: bool = True
+    has_partial_occupancies: bool = True
 
     def to_cif(self, filename: Path | str) -> None:
         """Write this structure to a cif file, with its symmetry.
@@ -76,7 +71,7 @@ def _fit(
     *,
     symprec: float,
     angle_tolerance: float,
-    use_density: bool = True,
+    has_partial_occupancies: bool = True,
 ) -> CrystallizerResult:
     """Fit `geometry` at one tolerance and assemble the result.
 
@@ -90,7 +85,7 @@ def _fit(
         Symmetry tolerance (Ångstrom).
     angle_tolerance : float
         Angle tolerance (degrees).
-    use_density : bool
+    has_partial_occupancies : bool
         Whether `occupancies` carries the density-derived occupancies, recorded
         on the result. It does not change the fit -- the flag is applied when
         the occupancies are built, see
@@ -130,7 +125,7 @@ def _fit(
         spacegroup_symbol=spacegroup_symbol,
         spacegroup_number=spacegroup_number,
         symprec=symprec,
-        use_density=use_density,
+        has_partial_occupancies=has_partial_occupancies,
     )
 
 
@@ -257,7 +252,7 @@ class CrystallizerScan:
             self.occupancies,
             symprec=symprec,
             angle_tolerance=self.angle_tolerance,
-            use_density=self.use_density,
+            has_partial_occupancies=self.use_density,
         )
 
     def at_level(self, level: SymmetryLevel) -> CrystallizerResult:
@@ -349,14 +344,9 @@ class Crystallizer:
     - [crystallize_at][gemdat.crystallizer.Crystallizer.crystallize_at] fits a
       tolerance you already know, without scanning.
 
-    Incorporating the density-derived occupancies (``use_density=True``, the
-    default) gives realistic partial site occupancies, but those numbers carry
-    the statistical noise of the finite MD run. Switching it off
-    (``use_density=False``) keeps only the geometry: sites are still *located*
-    from the density peaks (the only way to find them), but every mobile site
-    is emitted at full occupancy 1.0, giving a clean idealised site set without
-    MD occupancy statistics. The fitted symmetry is identical either way -- the
-    symmetry search always runs on the geometry alone.
+    Incorporating the density-derived occupancies (``use_density=True``)
+    gives realistic partial site occupancies. The resulting structure is exactly
+    the same except for the densities.
     """
 
     def __init__(
@@ -433,9 +423,7 @@ class Crystallizer:
             [gemdat.volume.Volume.to_structure][].
         with_occupancies : bool
             If True (default), each site carries its density-derived partial
-            occupancy (the MD time-fraction the site is occupied). If False,
-            every site is returned at nominal full occupancy -- only the site
-            positions (density-peak centroids) are kept.
+            occupancy.
         **find_peaks_kwargs : dict
             Passed through to [gemdat.volume.Volume.find_peaks][].
 
@@ -494,27 +482,11 @@ class Crystallizer:
     ) -> tuple[Structure, np.ndarray]:
         """Combine framework + mobile sites into a geometry-only structure.
 
-        The returned structure has every site at full occupancy (element
-        symbols only). Symmetry must be searched on this structure: the
-        per-site occupancies are continuous floats, and feeding them to
-        the symmetry finder would make every mobile site distinct and
-        collapse the result to P1. The occupancies are returned
-        separately, aligned to the structure's site order (framework
-        sites are 1.0), so they can be averaged over the symmetry-
-        equivalent classes afterwards.
-
         Extracting the density peaks dominates the cost of everything
         downstream, and the same geometry is reused by repeated
         `crystallize`/`scan`/`to_cif` calls, so the result is cached per
         set of arguments. Arguments that cannot be hashed (e.g. an
         explicit `peaks` array) simply bypass the cache.
-
-        If ``use_density`` is False the mobile occupancies are all set to
-        1.0. The sites are still located exactly the same way (from the
-        density peaks), only the occupancy weighting is dropped, so the
-        geometry structure -- and therefore the fitted symmetry -- does not
-        depend on this flag. It is applied after the cache, so toggling it
-        never re-extracts the peaks.
         """
         key = tuple(sorted(find_peaks_kwargs.items()))
         try:
@@ -627,12 +599,8 @@ class Crystallizer:
             Fraction of the maximum density used as the segmentation floor.
         use_density : bool
             Whether to incorporate the density-derived occupancy information.
-            If True (default), the mobile sites carry their partial
-            occupancies, averaged per symmetry orbit -- realistic occupancies,
-            but they carry the MD occupancy noise. If False, the mobile sites
-            are still located from the density peaks but emitted at full
-            occupancy 1.0 -- a clean idealised site set without MD occupancy
-            statistics. The fitted space group is unaffected by this flag.
+            If True (default), the mobile sites retain their partial
+            occupancies.
         **find_peaks_kwargs : dict
             Passed through to [gemdat.volume.Volume.find_peaks][].
 
@@ -690,12 +658,8 @@ class Crystallizer:
             Fraction of the maximum density used as the segmentation floor.
         use_density : bool
             Whether to incorporate the density-derived occupancy information.
-            If True (default), the mobile sites carry their partial
-            occupancies, averaged per symmetry orbit -- realistic occupancies,
-            but they carry the MD occupancy noise. If False, the mobile sites
-            are still located from the density peaks but emitted at full
-            occupancy 1.0 -- a clean idealised site set without MD occupancy
-            statistics. The fitted space group is unaffected by this flag.
+            If True (default), the mobile sites retain their partial
+            occupancies.
         **find_peaks_kwargs : dict
             Passed through to [gemdat.volume.Volume.find_peaks][].
 
@@ -780,12 +744,8 @@ class Crystallizer:
             Fraction of the maximum density used as the segmentation floor.
         use_density : bool
             Whether to incorporate the density-derived occupancy information.
-            If True (default), the mobile sites carry their partial
-            occupancies, averaged per symmetry orbit -- realistic occupancies,
-            but they carry the MD occupancy noise. If False, the mobile sites
-            are still located from the density peaks but emitted at full
-            occupancy 1.0 -- a clean idealised site set without MD occupancy
-            statistics. The fitted space group is unaffected by this flag.
+            If True (default), the mobile sites retain their partial
+            occupancies.
         **find_peaks_kwargs : dict
             Passed through to [gemdat.volume.Volume.find_peaks][].
 
@@ -809,7 +769,7 @@ class Crystallizer:
             occupancies,
             symprec=symprec,
             angle_tolerance=angle_tolerance,
-            use_density=use_density,
+            has_partial_occupancies=use_density,
         )
 
     def _geometry_and_analyzer(

--- a/src/gemdat/crystallizer.py
+++ b/src/gemdat/crystallizer.py
@@ -28,20 +28,29 @@ class CrystallizerResult:
     ----------
     structure : Structure
         Full structure (static framework + density-derived mobile sites), with
-        partial occupancies and occupancies averaged over symmetry-equivalent
-        sites.
+        occupancies averaged over symmetry-equivalent sites. If ``use_density``
+        is True the mobile sites carry their density-derived partial
+        occupancies (the MD time-fraction the site is occupied); if False every
+        mobile site is emitted at full occupancy 1.0 and the structure is the
+        idealised site framework without MD occupancy statistics. Framework
+        sites are always fully occupied.
     spacegroup_symbol : str
         International symbol of the fitted space group.
     spacegroup_number : int
         International number of the fitted space group.
     symprec : float
         Symmetry tolerance (in Ångstrom) that produced the highest-symmetry fit.
+    use_density : bool
+        Whether density-derived partial occupancies were written into
+        ``structure`` (True) or every mobile site was set to full occupancy
+        (False).
     """
 
     structure: Structure
     spacegroup_symbol: str
     spacegroup_number: int
     symprec: float
+    use_density: bool = True
 
 
 class Crystallizer:
@@ -51,6 +60,15 @@ class Crystallizer:
     with partial occupancies, these are combined with the time-averaged static
     host framework, and the highest crystal symmetry consistent with the
     resulting structure is fitted. The result can be written to a cif file.
+
+    Incorporating the density-derived occupancies (``use_density=True``, the
+    default) gives realistic partial site occupancies, but those numbers carry
+    the statistical noise of the finite MD run. Switching it off
+    (``use_density=False``) keeps only the geometry: sites are still *located*
+    from the density peaks (the only way to find them), but every mobile site
+    is emitted at full occupancy 1.0, giving a clean idealised site set without
+    MD occupancy statistics. The fitted symmetry is identical either way -- the
+    symmetry search always runs on the geometry alone.
     """
 
     def __init__(
@@ -115,31 +133,37 @@ class Crystallizer:
         self,
         *,
         background_level: float = 0.1,
+        with_occupancies: bool = True,
         **find_peaks_kwargs,
     ) -> Structure:
-        """Extract the mobile-species sites from the density, with partial
-        occupancies.
+        """Extract the mobile-species sites from the density.
 
         Parameters
         ----------
         background_level : float
             Fraction of the maximum density used as the segmentation floor, see
             [gemdat.volume.Volume.to_structure][].
+        with_occupancies : bool
+            If True (default), each site carries its density-derived partial
+            occupancy (the MD time-fraction the site is occupied). If False,
+            every site is returned at nominal full occupancy -- only the site
+            positions (density-peak centroids) are kept.
         **find_peaks_kwargs : dict
             Passed through to [gemdat.volume.Volume.find_peaks][].
 
         Returns
         -------
         structure : Structure
-            Structure of mobile sites with partial occupancies.
+            Structure of mobile sites. Occupancies are partial floats when
+            ``with_occupancies`` is True and 1.0 otherwise.
         """
         mobile = self.trajectory.filter(self.floating_specie)
         volume = mobile.to_volume(resolution=self.resolution)
         return volume.to_structure(
             specie=self.floating_specie,
             background_level=background_level,
-            return_occupancies=True,
-            n_frames=len(mobile),
+            return_occupancies=with_occupancies,
+            n_frames=len(mobile) if with_occupancies else None,
             **find_peaks_kwargs,
         )
 
@@ -177,6 +201,7 @@ class Crystallizer:
         self,
         *,
         background_level: float = 0.1,
+        use_density: bool = True,
         **find_peaks_kwargs,
     ) -> tuple[Structure, np.ndarray]:
         """Combine framework + mobile sites into a geometry-only structure.
@@ -189,6 +214,12 @@ class Crystallizer:
         separately, aligned to the structure's site order (framework
         sites are 1.0), so they can be averaged over the symmetry-
         equivalent classes afterwards.
+
+        If ``use_density`` is False the mobile occupancies are all set to
+        1.0 afterwards. The sites are still located exactly the same way
+        (from the density peaks), only the occupancy weighting is dropped,
+        so the geometry structure -- and therefore the fitted symmetry --
+        does not depend on this flag.
         """
         framework = self.framework()
         mobile = self.mobile_sites(background_level=background_level, **find_peaks_kwargs)
@@ -197,7 +228,10 @@ class Crystallizer:
         symbols += [next(iter(site.species.as_dict())) for site in mobile]
 
         occupancies = [1.0] * len(framework)
-        occupancies += [site.species.num_atoms for site in mobile]
+        if use_density:
+            occupancies += [site.species.num_atoms for site in mobile]
+        else:
+            occupancies += [1.0] * len(mobile)
 
         # `framework` is empty when every species is the floating specie (e.g.
         # an already Li-filtered trajectory); its `frac_coords` then has no
@@ -218,6 +252,7 @@ class Crystallizer:
         symprec_range: tuple[float, ...] = (0.01, 0.05, 0.1, 0.2, 0.3, 0.5),
         angle_tolerance: float = 5.0,
         background_level: float = 0.1,
+        use_density: bool = True,
         **find_peaks_kwargs,
     ) -> CrystallizerResult:
         """Build the full structure and fit the highest possible space group.
@@ -233,6 +268,14 @@ class Crystallizer:
             [pymatgen.symmetry.analyzer.SpacegroupAnalyzer][].
         background_level : float
             Fraction of the maximum density used as the segmentation floor.
+        use_density : bool
+            Whether to incorporate the density-derived occupancy information.
+            If True (default), the mobile sites carry their partial
+            occupancies, averaged per symmetry orbit -- realistic occupancies,
+            but they carry the MD occupancy noise. If False, the mobile sites
+            are still located from the density peaks but emitted at full
+            occupancy 1.0 -- a clean idealised site set without MD occupancy
+            statistics. The fitted space group is unaffected by this flag.
         **find_peaks_kwargs : dict
             Passed through to [gemdat.volume.Volume.find_peaks][].
 
@@ -242,7 +285,9 @@ class Crystallizer:
             The symmetrized structure and the fitted space group.
         """
         geometry, occupancies = self._geometry_and_occupancies(
-            background_level=background_level, **find_peaks_kwargs
+            background_level=background_level,
+            use_density=use_density,
+            **find_peaks_kwargs,
         )
 
         best_symprec = None
@@ -290,6 +335,7 @@ class Crystallizer:
             spacegroup_symbol=sga.get_space_group_symbol(),
             spacegroup_number=sga.get_space_group_number(),
             symprec=best_symprec,
+            use_density=use_density,
         )
 
     def to_cif(self, filename: Path | str, **kwargs) -> CrystallizerResult:

--- a/tests/crystallizer_test.py
+++ b/tests/crystallizer_test.py
@@ -120,7 +120,7 @@ def test_crystallize_use_density_false(crystal_trajectory):
 
     result = cr.crystallize(use_density=False)
 
-    assert result.use_density is False
+    assert result.has_partial_occupancies is False
     occupancies = _mobile_occupancies(result.structure)
     assert len(occupancies) > 0
     assert all(occ == 1.0 for occ in occupancies)
@@ -134,7 +134,7 @@ def test_crystallize_use_density_default_unchanged(crystal_trajectory):
     cr = Crystallizer.from_trajectory(crystal_trajectory, floating_specie='Li')
 
     for result in (cr.crystallize(), cr.crystallize(use_density=True)):
-        assert result.use_density is True
+        assert result.has_partial_occupancies is True
         assert result.spacegroup_number == 12
 
         occupancies = _mobile_occupancies(result.structure)
@@ -165,7 +165,7 @@ def test_scan_use_density_false(crystal_trajectory):
     scan = cr.scan(use_density=False)
 
     for result in (scan.best(), scan.at(0.1)):
-        assert result.use_density is False
+        assert result.has_partial_occupancies is False
         occupancies = _mobile_occupancies(result.structure)
         assert len(occupancies) > 0
         assert all(occ == 1.0 for occ in occupancies)
@@ -176,7 +176,7 @@ def test_crystallize_at_use_density_false(crystal_trajectory):
 
     result = cr.crystallize_at(0.1, use_density=False)
 
-    assert result.use_density is False
+    assert result.has_partial_occupancies is False
     occupancies = _mobile_occupancies(result.structure)
     assert len(occupancies) > 0
     assert all(occ == 1.0 for occ in occupancies)
@@ -336,7 +336,7 @@ def test_result_is_a_plain_value(crystal_trajectory):
         'spacegroup_symbol',
         'spacegroup_number',
         'symprec',
-        'use_density',
+        'has_partial_occupancies',
     }
 
 

--- a/tests/crystallizer_test.py
+++ b/tests/crystallizer_test.py
@@ -104,6 +104,66 @@ def test_to_cif(crystal_trajectory, tmp_path):
     assert '_symmetry_space_group_name_H-M' in filename.read_text()
 
 
+def _mobile_occupancies(structure, specie='Li'):
+    """Occupancies of the mobile-species sites in a (crystallized)
+    structure."""
+    return [site.species.num_atoms for site in structure if specie in site.species.as_dict()]
+
+
+def test_crystallize_use_density_false(crystal_trajectory):
+    cr = Crystallizer.from_trajectory(crystal_trajectory, floating_specie='Li')
+
+    result = cr.crystallize(use_density=False)
+
+    assert result.use_density is False
+    occupancies = _mobile_occupancies(result.structure)
+    assert len(occupancies) > 0
+    assert all(occ == 1.0 for occ in occupancies)
+
+
+def test_crystallize_use_density_default_unchanged(crystal_trajectory):
+    # Baseline captured from the pre-change code on this fixture (default
+    # resolution 0.2): highest space group is C2/m (12) at symprec 0.1, and
+    # the mobile sites end up with partial occupancy.
+    cr = Crystallizer.from_trajectory(crystal_trajectory, floating_specie='Li')
+
+    for result in (cr.crystallize(), cr.crystallize(use_density=True)):
+        assert result.use_density is True
+        assert result.spacegroup_number == 12
+        assert result.symprec == 0.1
+
+        occupancies = _mobile_occupancies(result.structure)
+        assert len(occupancies) > 0
+        assert any(occ < 1.0 for occ in occupancies)
+        assert all(0 < occ <= 1.0 for occ in occupancies)
+
+
+def test_to_cif_use_density_false(crystal_trajectory, tmp_path):
+    cr = Crystallizer.from_trajectory(crystal_trajectory, floating_specie='Li')
+
+    filename = tmp_path / 'crystallized_no_density.cif'
+    cr.to_cif(filename, use_density=False)
+
+    assert filename.exists()
+
+    reread = read_cif(filename)
+    occupancies = _mobile_occupancies(reread)
+    assert len(occupancies) > 0
+    assert all(occ == 1.0 for occ in occupancies)
+
+
+def test_mobile_sites_with_occupancies_false(crystal_trajectory):
+    cr = Crystallizer.from_trajectory(crystal_trajectory, floating_specie='Li', resolution=0.2)
+
+    mobile = cr.mobile_sites(with_occupancies=False)
+
+    assert isinstance(mobile, Structure)
+    assert len(mobile) > 0
+    for site in mobile:
+        assert 'Li' in site.species.as_dict()
+        assert site.species.num_atoms == 1.0
+
+
 def test_framework_rejects_variable_lattice(variable_lattice_trajectory):
     crystallizer = Crystallizer(trajectory=variable_lattice_trajectory, floating_specie='Li')
 


### PR DESCRIPTION
Closes part of #421 (point 4: "Can we somehow incorporate density (or not)"). Adds a `use_density` toggle to `Crystallizer.crystallize()` / `to_cif()` (and a matching `with_occupancies` kwarg on `mobile_sites()`): with the default `True` the mobile sites keep their density-derived partial occupancies as before, while `use_density=False` emits every mobile site at occupancy 1.0, so you can write CIF files without partial occupancies. Sites are still located from the density peaks either way, so the fitted space group and symprec are identical in both modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
